### PR TITLE
Credit Card Receipts — Sage design + full module build

### DIFF
--- a/app/api/receipts/cards/[card]/route.ts
+++ b/app/api/receipts/cards/[card]/route.ts
@@ -1,0 +1,20 @@
+/**
+ * DELETE /api/receipts/cards/[card] — unassign a card (card = card_last4)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { unassignCard } from '@/lib/receipts/cards-store';
+
+export async function DELETE(req: NextRequest, { params }: { params: { card: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const ok = unassignCard(params.card);
+    if (!ok) return NextResponse.json({ error: 'Assignment not found' }, { status: 404 });
+    return NextResponse.json({ ok: true, card_last4: params.card });
+  } catch (err: any) {
+    console.error('[receipts/cards/[card]] DELETE error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/cards/route.ts
+++ b/app/api/receipts/cards/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET  /api/receipts/cards   — card roster (+ assigned/unassigned counts)
+ * POST /api/receipts/cards   — assign/reassign a card: { card_last4, assignee_email, cardholder_name? }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { listCards, assignCard, getCardStats } from '@/lib/receipts/cards-store';
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return NextResponse.json({ cards: listCards(), stats: getCardStats() });
+  } catch (err: any) {
+    console.error('[receipts/cards] GET error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const body = await req.json();
+    if (!body?.card_last4 || !body?.assignee_email) {
+      return NextResponse.json({ error: 'card_last4 and assignee_email are required' }, { status: 400 });
+    }
+    const assignment = assignCard({
+      card_last4: String(body.card_last4),
+      assignee_email: String(body.assignee_email),
+      cardholder_name: body.cardholder_name ? String(body.cardholder_name) : '',
+      assigned_by: user.email,
+    });
+    return NextResponse.json({ assignment }, { status: 201 });
+  } catch (err: any) {
+    console.error('[receipts/cards] POST error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/integrations/plaid/exchange/route.ts
+++ b/app/api/receipts/integrations/plaid/exchange/route.ts
@@ -1,0 +1,28 @@
+/**
+ * POST /api/receipts/integrations/plaid/exchange — exchange a Plaid public_token
+ * (from Link onSuccess) for an access_token and store the connected item.
+ * Body: { public_token, institution_name? }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { exchangePublicToken } from '@/lib/receipts/plaid-sync';
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const body = await req.json();
+    if (!body?.public_token) {
+      return NextResponse.json({ error: 'public_token is required' }, { status: 400 });
+    }
+    const result = await exchangePublicToken(String(body.public_token), {
+      institutionName: body.institution_name ? String(body.institution_name) : '',
+      connectedBy: user.email,
+    });
+    return NextResponse.json({ ok: true, ...result }, { status: 201 });
+  } catch (err: any) {
+    console.error('[receipts/integrations/plaid/exchange] POST error:', err?.message);
+    return NextResponse.json({ error: err?.message || 'Exchange failed' }, { status: 400 });
+  }
+}

--- a/app/api/receipts/integrations/plaid/link-token/route.ts
+++ b/app/api/receipts/integrations/plaid/link-token/route.ts
@@ -1,0 +1,20 @@
+/**
+ * POST /api/receipts/integrations/plaid/link-token — create a Plaid Link token
+ * for the browser to open Plaid Link with.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { createLinkToken } from '@/lib/receipts/plaid-sync';
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const linkToken = await createLinkToken(user.email);
+    return NextResponse.json({ link_token: linkToken });
+  } catch (err: any) {
+    console.error('[receipts/integrations/plaid/link-token] POST error:', err?.message);
+    return NextResponse.json({ error: err?.message || 'Could not create link token' }, { status: 400 });
+  }
+}

--- a/app/api/receipts/integrations/plaid/route.ts
+++ b/app/api/receipts/integrations/plaid/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET    /api/receipts/integrations/plaid           — connection status + connected items (no tokens)
+ * DELETE /api/receipts/integrations/plaid?item_id=…  — disconnect an item
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { hasPlaidCredentials } from '@/lib/receipts/plaid-sync';
+import { listPublicItems, deleteItem } from '@/lib/receipts/plaid-store';
+
+export async function GET(req: NextRequest) {
+  const user = getCurrentUser(req);
+  if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({
+    linkConfigured: hasPlaidCredentials(),
+    env: process.env.PLAID_ENV || 'sandbox',
+    items: listPublicItems(),
+  });
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const itemId = req.nextUrl.searchParams.get('item_id');
+    if (!itemId) return NextResponse.json({ error: 'item_id is required' }, { status: 400 });
+    const ok = deleteItem(itemId);
+    if (!ok) return NextResponse.json({ error: 'Item not found' }, { status: 404 });
+    return NextResponse.json({ ok: true, item_id: itemId });
+  } catch (err: any) {
+    console.error('[receipts/integrations/plaid] DELETE error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/reports/[id]/export/route.ts
+++ b/app/api/receipts/reports/[id]/export/route.ts
@@ -1,0 +1,21 @@
+/**
+ * POST /api/receipts/reports/[id]/export — push an approved report to QBO as a
+ * CreditCard Purchase. Marks the report closed + records the QBO Purchase Id on success.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { exportReportToQbo } from '@/lib/receipts/qbo-export';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const result = await exportReportToQbo(params.id);
+    return NextResponse.json(result);
+  } catch (err: any) {
+    console.error('[receipts/reports/[id]/export] POST error:', err?.message);
+    // Surface the QBO/validation message to the UI (it's actionable, not a secret).
+    return NextResponse.json({ error: err?.message || 'Export failed' }, { status: 400 });
+  }
+}

--- a/app/api/receipts/reports/[id]/route.ts
+++ b/app/api/receipts/reports/[id]/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET   /api/receipts/reports/[id]  — one report + its receipts
+ * PATCH /api/receipts/reports/[id]  — change status: { status: 'approved'|'closed'|'submitted' }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { getReportById, updateReportStatus, type ReportStatus } from '@/lib/receipts/reports-store';
+
+const VALID: ReportStatus[] = ['submitted', 'approved', 'closed'];
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const report = getReportById(params.id);
+    if (!report) return NextResponse.json({ error: 'Report not found' }, { status: 404 });
+    return NextResponse.json({ report });
+  } catch (err: any) {
+    console.error('[receipts/reports/[id]] GET error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const body = await req.json();
+    if (!VALID.includes(body?.status)) {
+      return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+    }
+    const report = updateReportStatus(params.id, {
+      status: body.status,
+      approver_email: user.email,
+    });
+    if (!report) return NextResponse.json({ error: 'Report not found' }, { status: 404 });
+    return NextResponse.json({ report });
+  } catch (err: any) {
+    console.error('[receipts/reports/[id]] PATCH error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/reports/route.ts
+++ b/app/api/receipts/reports/route.ts
@@ -1,0 +1,56 @@
+/**
+ * GET  /api/receipts/reports  — list reports (?status=submitted|approved|closed) + status counts
+ * POST /api/receipts/reports  — create a report from receipts: { receiptIds: [...], notes? }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import {
+  listReports,
+  getReportStatusCounts,
+  createReport,
+  type ReportStatus,
+} from '@/lib/receipts/reports-store';
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const status = req.nextUrl.searchParams.get('status') as ReportStatus | null;
+    const valid = status === 'submitted' || status === 'approved' || status === 'closed';
+    return NextResponse.json({
+      reports: listReports(valid ? status! : undefined),
+      counts: getReportStatusCounts(),
+    });
+  } catch (err: any) {
+    console.error('[receipts/reports] GET error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const body = await req.json();
+    const receiptIds = Array.isArray(body?.receiptIds) ? body.receiptIds.map(String) : [];
+    if (receiptIds.length === 0) {
+      return NextResponse.json({ error: 'receiptIds is required' }, { status: 400 });
+    }
+    const report = createReport({
+      submitted_by: user.email,
+      receiptIds,
+      notes: body.notes ? String(body.notes) : '',
+    });
+    if (report.expense_count === 0) {
+      return NextResponse.json(
+        { error: 'No eligible receipts (already on a report or not found)' },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({ report }, { status: 201 });
+  } catch (err: any) {
+    console.error('[receipts/reports] POST error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/transactions/[id]/route.ts
+++ b/app/api/receipts/transactions/[id]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * GET    /api/receipts/transactions/[id]  — one Amex transaction
+ * PATCH  /api/receipts/transactions/[id]  — edit fields (merchant, category, …)
+ * DELETE /api/receipts/transactions/[id]  — delete
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import {
+  getTransactionById,
+  updateTransaction,
+  deleteTransaction,
+} from '@/lib/receipts/transactions-store';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const txn = getTransactionById(params.id);
+    if (!txn) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 });
+    return NextResponse.json({ transaction: txn });
+  } catch (err: any) {
+    console.error('[receipts/transactions/[id]] GET error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const body = await req.json();
+    const txn = updateTransaction(params.id, body);
+    if (!txn) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 });
+    return NextResponse.json({ transaction: txn });
+  } catch (err: any) {
+    console.error('[receipts/transactions/[id]] PATCH error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const ok = deleteTransaction(params.id);
+    if (!ok) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 });
+    return NextResponse.json({ ok: true, id: params.id });
+  } catch (err: any) {
+    console.error('[receipts/transactions/[id]] DELETE error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/transactions/match/route.ts
+++ b/app/api/receipts/transactions/match/route.ts
@@ -1,0 +1,20 @@
+/**
+ * POST /api/receipts/transactions/match — reconcile the whole feed: match every
+ * unmatched receipt against unmatched Amex transactions and persist the links.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { runAutoMatch } from '@/lib/receipts/receipt-service';
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const result = await runAutoMatch();
+    return NextResponse.json(result);
+  } catch (err: any) {
+    console.error('[receipts/transactions/match] POST error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/transactions/route.ts
+++ b/app/api/receipts/transactions/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET  /api/receipts/transactions   — list Amex transactions (+ stats).
+ *                                       Filters: ?status= ?card= ?q=
+ * POST /api/receipts/transactions   — import a statement:
+ *                                       • multipart/form-data file (CSV or XLSX), or
+ *                                       • JSON { rows: [{transaction_date, amount, merchant_name, ...}] }
+ *
+ * Parsing uses the `xlsx` dependency (reads CSV and XLSX). Headers are matched
+ * fuzzily so common Amex export layouts work without configuration.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import * as XLSX from 'xlsx';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import {
+  listTransactions,
+  getTransactionStats,
+  bulkInsert,
+  type AmexTransaction,
+  type TxnFilters,
+  type TxnMatchStatus,
+} from '@/lib/receipts/transactions-store';
+
+function buildFilters(req: NextRequest): TxnFilters {
+  const sp = req.nextUrl.searchParams;
+  const filters: TxnFilters = {};
+  const status = sp.get('status');
+  if (status === 'unmatched' || status === 'matched' || status === 'needs_review') {
+    filters.matchStatus = status as TxnMatchStatus;
+  }
+  const card = sp.get('card');
+  if (card) filters.cardLast4 = card;
+  const q = sp.get('q');
+  if (q) filters.search = q;
+  return filters;
+}
+
+// Map a loosely-keyed statement row to our transaction shape.
+function mapRow(row: Record<string, unknown>): Partial<AmexTransaction> {
+  const keys = Object.keys(row);
+  const find = (...needles: string[]) => {
+    const k = keys.find((key) => needles.some((n) => key.toLowerCase().includes(n)));
+    return k ? row[k] : undefined;
+  };
+  const num = (v: unknown) => {
+    if (typeof v === 'number') return v;
+    const n = parseFloat(String(v ?? '').replace(/[^0-9.\-]/g, ''));
+    return Number.isFinite(n) ? n : 0;
+  };
+  const last4 = (v: unknown) => String(v ?? '').replace(/\D/g, '').slice(-4);
+
+  const dateRaw = find('date');
+  let transaction_date = '';
+  if (dateRaw instanceof Date) transaction_date = dateRaw.toISOString().slice(0, 10);
+  else if (dateRaw != null) {
+    const d = new Date(String(dateRaw));
+    transaction_date = Number.isNaN(d.getTime()) ? String(dateRaw) : d.toISOString().slice(0, 10);
+  }
+
+  return {
+    transaction_date,
+    amount: num(find('amount')),
+    merchant_name: String(find('description', 'merchant') ?? '').trim(),
+    description_raw: String(find('description', 'merchant', 'detail') ?? '').trim(),
+    category: String(find('category') ?? '').trim(),
+    cardholder_name: String(find('card member', 'cardholder', 'member name') ?? '').trim(),
+    card_last4: last4(find('last 4', 'account', 'card number', 'card #', 'card no')),
+    reference_number: String(find('reference') ?? '').trim(),
+    source: 'import',
+  };
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const filters = buildFilters(req);
+    return NextResponse.json({
+      transactions: listTransactions(filters),
+      stats: getTransactionStats(filters),
+    });
+  } catch (err: any) {
+    console.error('[receipts/transactions] GET error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const contentType = req.headers.get('content-type') || '';
+    let rows: Array<Partial<AmexTransaction>> = [];
+
+    if (contentType.includes('multipart/form-data')) {
+      const form = await req.formData();
+      const file = form.get('file');
+      if (!(file instanceof File)) {
+        return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+      }
+      const buf = Buffer.from(await file.arrayBuffer());
+      const wb = XLSX.read(buf, { type: 'buffer', cellDates: true });
+      const sheet = wb.Sheets[wb.SheetNames[0]];
+      const json = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '' });
+      rows = json.map(mapRow).filter((r) => r.transaction_date && (r.amount || r.merchant_name));
+    } else {
+      const body = await req.json();
+      const raw = Array.isArray(body?.rows) ? body.rows : [];
+      rows = raw.map((r: Record<string, unknown>) => mapRow(r));
+    }
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: 'No valid rows found in import' }, { status: 400 });
+    }
+
+    const result = bulkInsert(rows);
+    return NextResponse.json({ ...result, total: rows.length }, { status: 201 });
+  } catch (err: any) {
+    console.error('[receipts/transactions] POST error:', err?.message);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/receipts/transactions/sync/route.ts
+++ b/app/api/receipts/transactions/sync/route.ts
@@ -1,0 +1,26 @@
+/**
+ * GET  /api/receipts/transactions/sync — is Plaid configured? { configured: boolean }
+ * POST /api/receipts/transactions/sync — pull Amex transactions from Plaid into the feed.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth/currentUser';
+import { syncAmexFromPlaid, isPlaidConfigured } from '@/lib/receipts/plaid-sync';
+
+export async function GET(req: NextRequest) {
+  const user = getCurrentUser(req);
+  if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  return NextResponse.json({ configured: isPlaidConfigured() });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = getCurrentUser(req);
+    if (!user.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const result = await syncAmexFromPlaid();
+    return NextResponse.json(result, { status: 201 });
+  } catch (err: any) {
+    console.error('[receipts/transactions/sync] POST error:', err?.message);
+    return NextResponse.json({ error: err?.message || 'Sync failed' }, { status: 400 });
+  }
+}

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -800,6 +800,10 @@ Return a JSON object with these exact fields. Return ONLY valid JSON, no explana
     CREATE INDEX IF NOT EXISTS idx_expense_reports_status ON expense_reports(status);
     CREATE INDEX IF NOT EXISTS idx_expense_reports_submitted_by ON expense_reports(submitted_by);
   `);
+  // QBO export result (populated when an approved report is pushed to QuickBooks).
+  ensureColumn('expense_reports', 'qbo_purchase_id', 'qbo_purchase_id TEXT');
+  ensureColumn('expense_reports', 'qbo_exported_at', 'qbo_exported_at TEXT');
+  ensureColumn('expense_reports', 'qbo_export_error', 'qbo_export_error TEXT');
 
   console.log('[DB] Migrations completed successfully');
 }

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -725,5 +725,81 @@ Return a JSON object with these exact fields. Return ONLY valid JSON, no explana
     CREATE INDEX IF NOT EXISTS idx_receipts_created ON receipts(created_at);
   `);
 
+  // Link a receipt to the expense report it belongs to (nullable).
+  ensureColumn('receipts', 'report_id', 'report_id TEXT');
+
+  // ─── Amex transactions (Credit Card Receipts module — McKay) ─────────────
+  // Card-charge feed. Populated by statement import today (CSV/XLSX); a Plaid
+  // sync can write the same shape later. Reconciled against receipts.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS amex_transactions (
+      id                 TEXT PRIMARY KEY,
+      transaction_date   TEXT,
+      amount             REAL,
+      merchant_name      TEXT,
+      description_raw    TEXT,
+      category           TEXT,
+      card_last4         TEXT,
+      cardholder_name    TEXT,
+      reference_number   TEXT,
+      match_status       TEXT DEFAULT 'unmatched',
+      matched_receipt_id TEXT,
+      match_score        INTEGER,
+      source             TEXT DEFAULT 'import',
+      created_at         TEXT,
+      updated_at         TEXT
+    );
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_amex_match_status ON amex_transactions(match_status);
+    CREATE INDEX IF NOT EXISTS idx_amex_card ON amex_transactions(card_last4);
+    CREATE INDEX IF NOT EXISTS idx_amex_date ON amex_transactions(transaction_date);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_amex_dedupe
+      ON amex_transactions(transaction_date, amount, merchant_name, card_last4);
+  `);
+
+  // ─── Card assignments (Credit Card Receipts module — McKay) ──────────────
+  // Maps an Amex card (last 4) to the user who manages its receipts.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS card_assignments (
+      id              TEXT PRIMARY KEY,
+      card_last4      TEXT,
+      cardholder_name TEXT,
+      assignee_email  TEXT,
+      assigned_by     TEXT,
+      assigned_at     TEXT,
+      is_active       INTEGER DEFAULT 1,
+      created_at      TEXT,
+      updated_at      TEXT
+    );
+  `);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_card_assignments_card ON card_assignments(card_last4);
+  `);
+
+  // ─── Expense reports (Credit Card Receipts module — McKay) ───────────────
+  // A bundle of receipts submitted together: submitted → approved → closed.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS expense_reports (
+      id             TEXT PRIMARY KEY,
+      display_number INTEGER,
+      submitted_by   TEXT,
+      submitted_at   TEXT,
+      status         TEXT DEFAULT 'submitted',
+      approver_email TEXT,
+      approved_at    TEXT,
+      closed_at      TEXT,
+      total_amount   REAL DEFAULT 0,
+      expense_count  INTEGER DEFAULT 0,
+      notes          TEXT,
+      created_at     TEXT,
+      updated_at     TEXT
+    );
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_expense_reports_status ON expense_reports(status);
+    CREATE INDEX IF NOT EXISTS idx_expense_reports_submitted_by ON expense_reports(submitted_by);
+  `);
+
   console.log('[DB] Migrations completed successfully');
 }

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -805,5 +805,22 @@ Return a JSON object with these exact fields. Return ONLY valid JSON, no explana
   ensureColumn('expense_reports', 'qbo_exported_at', 'qbo_exported_at TEXT');
   ensureColumn('expense_reports', 'qbo_export_error', 'qbo_export_error TEXT');
 
+  // ─── Plaid items (Credit Card Receipts module — McKay) ───────────────────
+  // One row per Plaid-connected institution. access_token is a secret at rest
+  // (same trust model as the platform's QBO token store) — never returned by the API.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS plaid_items (
+      id               TEXT PRIMARY KEY,
+      item_id          TEXT,
+      access_token     TEXT,
+      institution_name TEXT,
+      connected_by     TEXT,
+      last_synced_at   TEXT,
+      created_at       TEXT,
+      updated_at       TEXT
+    );
+  `);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_plaid_items_item ON plaid_items(item_id);`);
+
   console.log('[DB] Migrations completed successfully');
 }

--- a/lib/receipts/cards-store.ts
+++ b/lib/receipts/cards-store.ts
@@ -1,0 +1,134 @@
+/**
+ * lib/receipts/cards-store.ts
+ *
+ * Corporate-card roster for the receipts module. A "card" is a distinct
+ * card_last4 seen across amex_transactions / receipts, optionally assigned to a
+ * managing user via the card_assignments table.
+ */
+
+import { randomUUID } from 'crypto';
+import { getDatabase } from '../db/client';
+
+export interface CardAssignment {
+  id: string;
+  card_last4: string;
+  cardholder_name: string;
+  assignee_email: string;
+  assigned_by: string;
+  assigned_at: string;
+  is_active: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CardRow {
+  card_last4: string;
+  cardholder_name: string;
+  assignee_email: string | null;
+  txn_count: number;
+  receipt_count: number;
+  assigned: boolean;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Build the card roster by unioning card_last4 from transactions + receipts and
+ * joining the active assignment (if any).
+ */
+export function listCards(): CardRow[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `
+      WITH cards AS (
+        SELECT card_last4 FROM amex_transactions WHERE card_last4 IS NOT NULL AND card_last4 <> ''
+        UNION
+        SELECT card_last4 FROM receipts WHERE card_last4 IS NOT NULL AND card_last4 <> ''
+        UNION
+        SELECT card_last4 FROM card_assignments WHERE card_last4 IS NOT NULL AND card_last4 <> ''
+      )
+      SELECT
+        c.card_last4 AS card_last4,
+        COALESCE(ca.cardholder_name, (
+          SELECT cardholder_name FROM amex_transactions a
+          WHERE a.card_last4 = c.card_last4 AND a.cardholder_name IS NOT NULL AND a.cardholder_name <> ''
+          LIMIT 1
+        ), '') AS cardholder_name,
+        ca.assignee_email AS assignee_email,
+        (SELECT COUNT(*) FROM amex_transactions a WHERE a.card_last4 = c.card_last4) AS txn_count,
+        (SELECT COUNT(*) FROM receipts r WHERE r.card_last4 = c.card_last4) AS receipt_count
+      FROM cards c
+      LEFT JOIN card_assignments ca ON ca.card_last4 = c.card_last4 AND ca.is_active = 1
+      ORDER BY c.card_last4
+    `
+    )
+    .all() as Array<Omit<CardRow, 'assigned'>>;
+
+  return rows.map((r) => ({ ...r, assigned: !!r.assignee_email }));
+}
+
+export function getAssignment(cardLast4: string): CardAssignment | null {
+  const db = getDatabase();
+  const row = db
+    .prepare('SELECT * FROM card_assignments WHERE card_last4 = ?')
+    .get(cardLast4) as CardAssignment | undefined;
+  return row ?? null;
+}
+
+/** Assign (or reassign) a card to a user. Upserts on card_last4. */
+export function assignCard(data: {
+  card_last4: string;
+  assignee_email: string;
+  cardholder_name?: string;
+  assigned_by?: string;
+}): CardAssignment {
+  const db = getDatabase();
+  const now = nowIso();
+  const existing = getAssignment(data.card_last4);
+
+  if (existing) {
+    db.prepare(
+      `UPDATE card_assignments
+       SET assignee_email = @assignee_email,
+           cardholder_name = COALESCE(NULLIF(@cardholder_name, ''), cardholder_name),
+           assigned_by = @assigned_by, assigned_at = @now, is_active = 1, updated_at = @now
+       WHERE card_last4 = @card_last4`
+    ).run({
+      card_last4: data.card_last4,
+      assignee_email: data.assignee_email,
+      cardholder_name: data.cardholder_name ?? '',
+      assigned_by: data.assigned_by ?? '',
+      now,
+    });
+  } else {
+    db.prepare(
+      `INSERT INTO card_assignments
+         (id, card_last4, cardholder_name, assignee_email, assigned_by, assigned_at, is_active, created_at, updated_at)
+       VALUES (@id, @card_last4, @cardholder_name, @assignee_email, @assigned_by, @now, 1, @now, @now)`
+    ).run({
+      id: randomUUID(),
+      card_last4: data.card_last4,
+      cardholder_name: data.cardholder_name ?? '',
+      assignee_email: data.assignee_email,
+      assigned_by: data.assigned_by ?? '',
+      now,
+    });
+  }
+  return getAssignment(data.card_last4)!;
+}
+
+/** Remove an assignment (deactivate). */
+export function unassignCard(cardLast4: string): boolean {
+  const db = getDatabase();
+  const info = db.prepare('DELETE FROM card_assignments WHERE card_last4 = ?').run(cardLast4);
+  return info.changes > 0;
+}
+
+export function getCardStats(): { total: number; assigned: number; unassigned: number } {
+  const cards = listCards();
+  const assigned = cards.filter((c) => c.assigned).length;
+  return { total: cards.length, assigned, unassigned: cards.length - assigned };
+}

--- a/lib/receipts/db-store.ts
+++ b/lib/receipts/db-store.ts
@@ -39,6 +39,7 @@ export interface Receipt {
   submitted_by: string;
   notes: string;
   image_path: string | null;
+  report_id: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/lib/receipts/plaid-store.ts
+++ b/lib/receipts/plaid-store.ts
@@ -1,0 +1,96 @@
+/**
+ * lib/receipts/plaid-store.ts
+ *
+ * Persistence for Plaid-connected items (institutions). The access_token is a
+ * secret at rest and is never exposed by the API layer — only listPublicItems()
+ * (which omits it) is returned to clients.
+ */
+
+import { randomUUID } from 'crypto';
+import { getDatabase } from '../db/client';
+
+export interface PlaidItem {
+  id: string;
+  item_id: string;
+  access_token: string;
+  institution_name: string;
+  connected_by: string;
+  last_synced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type PlaidItemPublic = Omit<PlaidItem, 'access_token'>;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function saveItem(data: {
+  item_id: string;
+  access_token: string;
+  institution_name?: string;
+  connected_by?: string;
+}): PlaidItem {
+  const db = getDatabase();
+  const now = nowIso();
+  const existing = db.prepare('SELECT * FROM plaid_items WHERE item_id = ?').get(data.item_id) as
+    | PlaidItem
+    | undefined;
+  if (existing) {
+    db.prepare(
+      `UPDATE plaid_items
+       SET access_token = @access_token,
+           institution_name = COALESCE(NULLIF(@institution_name, ''), institution_name),
+           updated_at = @now
+       WHERE item_id = @item_id`
+    ).run({ ...data, institution_name: data.institution_name ?? '', now });
+  } else {
+    db.prepare(
+      `INSERT INTO plaid_items
+         (id, item_id, access_token, institution_name, connected_by, last_synced_at, created_at, updated_at)
+       VALUES (@id, @item_id, @access_token, @institution_name, @connected_by, NULL, @now, @now)`
+    ).run({
+      id: randomUUID(),
+      item_id: data.item_id,
+      access_token: data.access_token,
+      institution_name: data.institution_name ?? '',
+      connected_by: data.connected_by ?? '',
+      now,
+    });
+  }
+  return db.prepare('SELECT * FROM plaid_items WHERE item_id = ?').get(data.item_id) as PlaidItem;
+}
+
+export function listItems(): PlaidItem[] {
+  const db = getDatabase();
+  return db.prepare('SELECT * FROM plaid_items ORDER BY datetime(created_at) DESC').all() as PlaidItem[];
+}
+
+export function listPublicItems(): PlaidItemPublic[] {
+  return listItems().map((i) => ({
+    id: i.id,
+    item_id: i.item_id,
+    institution_name: i.institution_name,
+    connected_by: i.connected_by,
+    last_synced_at: i.last_synced_at,
+    created_at: i.created_at,
+    updated_at: i.updated_at,
+  }));
+}
+
+export function getAccessTokens(): string[] {
+  return listItems()
+    .map((i) => i.access_token)
+    .filter(Boolean);
+}
+
+export function markSynced(): void {
+  const db = getDatabase();
+  db.prepare('UPDATE plaid_items SET last_synced_at = ?').run(nowIso());
+}
+
+export function deleteItem(itemId: string): boolean {
+  const db = getDatabase();
+  return db.prepare('DELETE FROM plaid_items WHERE item_id = ?').run(itemId).changes > 0;
+}

--- a/lib/receipts/plaid-sync.ts
+++ b/lib/receipts/plaid-sync.ts
@@ -1,0 +1,120 @@
+/**
+ * lib/receipts/plaid-sync.ts
+ *
+ * Pull Amex card transactions from Plaid into the amex_transactions table, in
+ * the same shape statement-import produces (so reconcile + dedupe just work).
+ *
+ * Uses the Plaid REST API directly via fetch — no SDK dependency. Env-gated and
+ * degrades with a clear error when not configured:
+ *   PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ACCESS_TOKEN, PLAID_ENV (sandbox|development|production)
+ *
+ * NOTE: untested against a live Plaid item (no credentials in this environment).
+ * The request/response mapping follows Plaid's /transactions/get contract.
+ */
+
+import { bulkInsert, type AmexTransaction } from './transactions-store';
+
+export function isPlaidConfigured(): boolean {
+  return !!(
+    process.env.PLAID_CLIENT_ID &&
+    process.env.PLAID_SECRET &&
+    process.env.PLAID_ACCESS_TOKEN
+  );
+}
+
+function plaidBaseUrl(): string {
+  const env = (process.env.PLAID_ENV || 'sandbox').toLowerCase();
+  if (env === 'production') return 'https://production.plaid.com';
+  if (env === 'development') return 'https://development.plaid.com';
+  return 'https://sandbox.plaid.com';
+}
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+interface PlaidTxn {
+  date: string;
+  amount: number;
+  name?: string;
+  merchant_name?: string;
+  account_id?: string;
+  transaction_id?: string;
+  category?: string[];
+  personal_finance_category?: { primary?: string };
+}
+interface PlaidAccount {
+  account_id: string;
+  mask?: string;
+  name?: string;
+}
+
+/**
+ * Sync transactions for the configured Plaid item into amex_transactions.
+ * Returns the import summary (inserted/skipped/total).
+ */
+export async function syncAmexFromPlaid(opts: { startDate?: string; endDate?: string } = {}): Promise<{
+  inserted: number;
+  skipped: number;
+  total: number;
+}> {
+  if (!isPlaidConfigured()) {
+    throw new Error(
+      'Plaid is not configured. Set PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ACCESS_TOKEN (and PLAID_ENV).'
+    );
+  }
+
+  const start_date = opts.startDate || isoDaysAgo(90);
+  const end_date = opts.endDate || new Date().toISOString().slice(0, 10);
+  const url = `${plaidBaseUrl()}/transactions/get`;
+
+  const all: PlaidTxn[] = [];
+  const accountsById = new Map<string, PlaidAccount>();
+  let offset = 0;
+  let total = Infinity;
+
+  // Paginate (Plaid returns total_transactions; page with count/offset).
+  while (offset < total) {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: process.env.PLAID_CLIENT_ID,
+        secret: process.env.PLAID_SECRET,
+        access_token: process.env.PLAID_ACCESS_TOKEN,
+        start_date,
+        end_date,
+        options: { count: 500, offset },
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Plaid /transactions/get failed (HTTP ${res.status}): ${text.slice(0, 300)}`);
+    }
+    const json: any = await res.json();
+    total = json.total_transactions ?? (json.transactions || []).length;
+    for (const a of (json.accounts || []) as PlaidAccount[]) accountsById.set(a.account_id, a);
+    const batch: PlaidTxn[] = json.transactions || [];
+    all.push(...batch);
+    if (batch.length === 0) break;
+    offset += batch.length;
+  }
+
+  const rows: Array<Partial<AmexTransaction>> = all.map((t) => {
+    const acct = t.account_id ? accountsById.get(t.account_id) : undefined;
+    return {
+      transaction_date: t.date,
+      amount: typeof t.amount === 'number' ? t.amount : 0,
+      merchant_name: t.merchant_name || t.name || '',
+      description_raw: t.name || '',
+      category: t.personal_finance_category?.primary || (t.category && t.category[0]) || '',
+      card_last4: acct?.mask ? acct.mask.slice(-4) : '',
+      cardholder_name: acct?.name || '',
+      reference_number: t.transaction_id || '',
+      source: 'plaid',
+    };
+  });
+
+  const result = bulkInsert(rows);
+  return { ...result, total: rows.length };
+}

--- a/lib/receipts/plaid-sync.ts
+++ b/lib/receipts/plaid-sync.ts
@@ -1,25 +1,31 @@
 /**
  * lib/receipts/plaid-sync.ts
  *
- * Pull Amex card transactions from Plaid into the amex_transactions table, in
- * the same shape statement-import produces (so reconcile + dedupe just work).
+ * Plaid integration for the Amex feed:
+ *   - Link flow helpers (create link token, exchange public token) used by the
+ *     Integrations page to connect an institution from the UI.
+ *   - syncAmexFromPlaid(): pull charges for every connected item into
+ *     amex_transactions, in the same shape statement-import produces (so
+ *     reconcile + dedupe just work).
  *
- * Uses the Plaid REST API directly via fetch — no SDK dependency. Env-gated and
- * degrades with a clear error when not configured:
- *   PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ACCESS_TOKEN, PLAID_ENV (sandbox|development|production)
+ * Uses the Plaid REST API directly via fetch — no SDK dependency. Connecting
+ * requires PLAID_CLIENT_ID + PLAID_SECRET (+ PLAID_ENV). Access tokens are
+ * obtained via Link and stored in plaid_items (not env), though a legacy
+ * PLAID_ACCESS_TOKEN env var is still honored if present.
  *
  * NOTE: untested against a live Plaid item (no credentials in this environment).
- * The request/response mapping follows Plaid's /transactions/get contract.
  */
 
 import { bulkInsert, type AmexTransaction } from './transactions-store';
+import { getAccessTokens, saveItem, markSynced } from './plaid-store';
 
+export function hasPlaidCredentials(): boolean {
+  return !!(process.env.PLAID_CLIENT_ID && process.env.PLAID_SECRET);
+}
+
+/** True when the Link flow can be started (client credentials present). */
 export function isPlaidConfigured(): boolean {
-  return !!(
-    process.env.PLAID_CLIENT_ID &&
-    process.env.PLAID_SECRET &&
-    process.env.PLAID_ACCESS_TOKEN
-  );
+  return hasPlaidCredentials();
 }
 
 function plaidBaseUrl(): string {
@@ -29,9 +35,61 @@ function plaidBaseUrl(): string {
   return 'https://sandbox.plaid.com';
 }
 
+async function plaidRequest(path: string, body: Record<string, unknown>): Promise<any> {
+  if (!hasPlaidCredentials()) {
+    throw new Error('Plaid is not configured. Set PLAID_CLIENT_ID and PLAID_SECRET (and PLAID_ENV).');
+  }
+  const res = await fetch(`${plaidBaseUrl()}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: process.env.PLAID_CLIENT_ID,
+      secret: process.env.PLAID_SECRET,
+      ...body,
+    }),
+  });
+  const json: any = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = json?.error_message || `Plaid ${path} failed (HTTP ${res.status})`;
+    throw new Error(msg);
+  }
+  return json;
+}
+
 function isoDaysAgo(days: number): string {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 }
+
+// ─── Link flow ─────────────────────────────────────────────────────────────
+
+export async function createLinkToken(userId: string): Promise<string> {
+  const json = await plaidRequest('/link/token/create', {
+    user: { client_user_id: userId || 'pcs-receipts-user' },
+    client_name: 'PCS Receipts',
+    products: ['transactions'],
+    country_codes: ['US'],
+    language: 'en',
+  });
+  return json.link_token;
+}
+
+export async function exchangePublicToken(
+  publicToken: string,
+  opts: { institutionName?: string; connectedBy?: string } = {}
+): Promise<{ item_id: string; institution_name: string }> {
+  const exchanged = await plaidRequest('/item/public_token/exchange', { public_token: publicToken });
+  const access_token = exchanged.access_token as string;
+  const item_id = exchanged.item_id as string;
+  saveItem({
+    item_id,
+    access_token,
+    institution_name: opts.institutionName || '',
+    connected_by: opts.connectedBy || '',
+  });
+  return { item_id, institution_name: opts.institutionName || '' };
+}
+
+// ─── Sync ──────────────────────────────────────────────────────────────────
 
 interface PlaidTxn {
   date: string;
@@ -49,72 +107,72 @@ interface PlaidAccount {
   name?: string;
 }
 
-/**
- * Sync transactions for the configured Plaid item into amex_transactions.
- * Returns the import summary (inserted/skipped/total).
- */
+function allTokens(): string[] {
+  const stored = getAccessTokens();
+  const env = process.env.PLAID_ACCESS_TOKEN;
+  return env ? Array.from(new Set([...stored, env])) : stored;
+}
+
+async function fetchTokenTransactions(accessToken: string, start_date: string, end_date: string): Promise<PlaidTxn[]> {
+  const all: PlaidTxn[] = [];
+  const accountsById = new Map<string, PlaidAccount>();
+  let offset = 0;
+  let total = Infinity;
+  while (offset < total) {
+    const json = await plaidRequest('/transactions/get', {
+      access_token: accessToken,
+      start_date,
+      end_date,
+      options: { count: 500, offset },
+    });
+    total = json.total_transactions ?? (json.transactions || []).length;
+    for (const a of (json.accounts || []) as PlaidAccount[]) accountsById.set(a.account_id, a);
+    const batch: PlaidTxn[] = json.transactions || [];
+    if (batch.length === 0) break;
+    // Attach account mask/name to each txn for mapping.
+    for (const t of batch) {
+      const acct = t.account_id ? accountsById.get(t.account_id) : undefined;
+      (t as any).__mask = acct?.mask;
+      (t as any).__acctName = acct?.name;
+    }
+    all.push(...batch);
+    offset += batch.length;
+  }
+  return all;
+}
+
 export async function syncAmexFromPlaid(opts: { startDate?: string; endDate?: string } = {}): Promise<{
   inserted: number;
   skipped: number;
   total: number;
 }> {
-  if (!isPlaidConfigured()) {
-    throw new Error(
-      'Plaid is not configured. Set PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ACCESS_TOKEN (and PLAID_ENV).'
-    );
+  const tokens = allTokens();
+  if (tokens.length === 0) {
+    throw new Error('No Plaid item connected. Connect an institution on the Integrations page first.');
   }
 
   const start_date = opts.startDate || isoDaysAgo(90);
   const end_date = opts.endDate || new Date().toISOString().slice(0, 10);
-  const url = `${plaidBaseUrl()}/transactions/get`;
 
-  const all: PlaidTxn[] = [];
-  const accountsById = new Map<string, PlaidAccount>();
-  let offset = 0;
-  let total = Infinity;
-
-  // Paginate (Plaid returns total_transactions; page with count/offset).
-  while (offset < total) {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        client_id: process.env.PLAID_CLIENT_ID,
-        secret: process.env.PLAID_SECRET,
-        access_token: process.env.PLAID_ACCESS_TOKEN,
-        start_date,
-        end_date,
-        options: { count: 500, offset },
-      }),
-    });
-    if (!res.ok) {
-      const text = await res.text();
-      throw new Error(`Plaid /transactions/get failed (HTTP ${res.status}): ${text.slice(0, 300)}`);
+  const rows: Array<Partial<AmexTransaction>> = [];
+  for (const token of tokens) {
+    const txns = await fetchTokenTransactions(token, start_date, end_date);
+    for (const t of txns) {
+      rows.push({
+        transaction_date: t.date,
+        amount: typeof t.amount === 'number' ? t.amount : 0,
+        merchant_name: t.merchant_name || t.name || '',
+        description_raw: t.name || '',
+        category: t.personal_finance_category?.primary || (t.category && t.category[0]) || '',
+        card_last4: (t as any).__mask ? String((t as any).__mask).slice(-4) : '',
+        cardholder_name: (t as any).__acctName || '',
+        reference_number: t.transaction_id || '',
+        source: 'plaid',
+      });
     }
-    const json: any = await res.json();
-    total = json.total_transactions ?? (json.transactions || []).length;
-    for (const a of (json.accounts || []) as PlaidAccount[]) accountsById.set(a.account_id, a);
-    const batch: PlaidTxn[] = json.transactions || [];
-    all.push(...batch);
-    if (batch.length === 0) break;
-    offset += batch.length;
   }
 
-  const rows: Array<Partial<AmexTransaction>> = all.map((t) => {
-    const acct = t.account_id ? accountsById.get(t.account_id) : undefined;
-    return {
-      transaction_date: t.date,
-      amount: typeof t.amount === 'number' ? t.amount : 0,
-      merchant_name: t.merchant_name || t.name || '',
-      description_raw: t.name || '',
-      category: t.personal_finance_category?.primary || (t.category && t.category[0]) || '',
-      card_last4: acct?.mask ? acct.mask.slice(-4) : '',
-      cardholder_name: acct?.name || '',
-      reference_number: t.transaction_id || '',
-      source: 'plaid',
-    };
-  });
-
   const result = bulkInsert(rows);
+  markSynced();
   return { ...result, total: rows.length };
 }

--- a/lib/receipts/qbo-export.ts
+++ b/lib/receipts/qbo-export.ts
@@ -1,0 +1,150 @@
+/**
+ * lib/receipts/qbo-export.ts
+ *
+ * Push an approved expense report to QuickBooks Online as a CreditCard
+ * **Purchase** (the correct entity for credit-card spend).
+ *
+ * This reuses the platform QBO module (lib/qbo) for connection + token handling
+ * and account/class lookups — it does NOT modify it. The Purchase POST is done
+ * here against the QBO REST API with the platform's stored token, because
+ * QBOClient only exposes Bill creation (Bills are for AP invoices, not card
+ * spend). If/when lib/qbo grows a createPurchase(), this can delegate to it.
+ *
+ * Requires an active QBO connection (managed by the platform at /api/qbo/auth).
+ * Degrades with a clear error when QBO isn't connected or accounts can't be resolved.
+ */
+
+import { qboClient } from '../qbo/qboClient';
+import { tokenStorage } from '../qbo/tokenStorage';
+import { getReportById, setReportQboResult, type ExpenseReport } from './reports-store';
+import type { Receipt } from './db-store';
+
+function qboBaseUrl(): string {
+  return (process.env.QBO_ENVIRONMENT || 'sandbox') === 'sandbox'
+    ? 'https://sandbox-quickbooks.api.intuit.com'
+    : 'https://quickbooks.api.intuit.com';
+}
+
+interface QboAccount {
+  id: string;
+  name: string;
+  fullName: string;
+  type: string;
+  acctNum?: string;
+}
+
+function leadingNumber(gl: string): string | null {
+  const m = (gl || '').match(/\d{4,6}/);
+  return m ? m[0] : null;
+}
+
+function resolveAccount(accounts: QboAccount[], gl: string): QboAccount | undefined {
+  if (!gl) return undefined;
+  const num = leadingNumber(gl);
+  const nameOnly = gl.replace(/^\d+\s*/, '').trim().toLowerCase();
+  return (
+    (num ? accounts.find((a) => a.acctNum === num) : undefined) ||
+    accounts.find((a) => a.fullName?.toLowerCase().endsWith(gl.toLowerCase())) ||
+    accounts.find((a) => a.name?.toLowerCase() === nameOnly)
+  );
+}
+
+export interface QboExportResult {
+  purchaseId: string;
+  report: (ExpenseReport & { receipts: Receipt[] }) | null;
+}
+
+export async function exportReportToQbo(reportId: string): Promise<QboExportResult> {
+  const report = getReportById(reportId);
+  if (!report) throw new Error('Report not found');
+  if (report.qbo_purchase_id) {
+    return { purchaseId: report.qbo_purchase_id, report };
+  }
+  if (report.status !== 'approved') {
+    throw new Error('Only approved reports can be exported to QuickBooks');
+  }
+  if (report.receipts.length === 0) {
+    throw new Error('Report has no receipts to export');
+  }
+
+  // Connection + fresh token (throws clearly if QBO isn't connected).
+  await qboClient.initialize();
+  await qboClient.ensureValidToken();
+  const tokens = await tokenStorage.getLatestTokens();
+  if (!tokens) throw new Error('QuickBooks is not connected. Connect it at /api/qbo/auth first.');
+
+  const accounts = (await qboClient.getAllAccounts()) as QboAccount[];
+  const classes = (await qboClient.getClasses()) as Array<{ id: string; name: string }>;
+
+  // The credit-card account the charges post against (AMEX 21100 by convention).
+  const amexAcctNum = process.env.QBO_AMEX_ACCOUNT_NUM || '21100';
+  const amex =
+    accounts.find((a) => a.acctNum === amexAcctNum) ||
+    accounts.find((a) => /amex|credit card/i.test(a.name));
+  if (!amex) {
+    const msg = `No credit-card account found in QBO (looked for acctNum ${amexAcctNum} or a name containing "AMEX").`;
+    setReportQboResult(reportId, { error: msg });
+    throw new Error(msg);
+  }
+
+  const unresolved: string[] = [];
+  const Line = report.receipts.map((r) => {
+    const acct = resolveAccount(accounts, r.gl_account || '');
+    if (!acct) unresolved.push(`${r.vendor || 'Unknown'} → "${r.gl_account || '(none)'}"`);
+    const cls = r.location
+      ? classes.find((c) => c.name.toLowerCase().includes(r.location.toLowerCase()))
+      : undefined;
+    return {
+      Amount: Number(r.amount) || 0,
+      DetailType: 'AccountBasedExpenseLineDetail',
+      Description: r.vendor || r.notes || '',
+      AccountBasedExpenseLineDetail: {
+        AccountRef: acct ? { value: acct.id } : undefined,
+        ClassRef: cls ? { value: cls.id } : undefined,
+      },
+    };
+  });
+
+  if (unresolved.length > 0) {
+    const msg = `Could not map ${unresolved.length} GL account(s) to QBO: ${unresolved.join('; ')}`;
+    setReportQboResult(reportId, { error: msg });
+    throw new Error(msg);
+  }
+
+  const payload = {
+    PaymentType: 'CreditCard',
+    AccountRef: { value: amex.id, name: amex.name },
+    TxnDate: (report.submitted_at || new Date().toISOString()).slice(0, 10),
+    PrivateNote: `PCS expense report #${report.display_number} (${report.expense_count} receipts)`,
+    Line,
+  };
+
+  const url = `${qboBaseUrl()}/v3/company/${tokens.realmId}/purchase?minorversion=70`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokens.accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    const msg = `QBO Purchase failed (HTTP ${res.status}): ${text.slice(0, 300)}`;
+    setReportQboResult(reportId, { error: msg });
+    throw new Error(msg);
+  }
+
+  const json: any = await res.json();
+  const purchaseId = json?.Purchase?.Id;
+  if (!purchaseId) {
+    const msg = 'QBO did not return a Purchase Id';
+    setReportQboResult(reportId, { error: msg });
+    throw new Error(msg);
+  }
+
+  const updated = setReportQboResult(reportId, { purchaseId });
+  return { purchaseId, report: updated };
+}

--- a/lib/receipts/receipt-service.ts
+++ b/lib/receipts/receipt-service.ts
@@ -21,6 +21,8 @@ import fs from 'fs';
 import path from 'path';
 import OpenAI from 'openai';
 import { convertPdfToBase64Images, formatImagesForOpenAI } from '../gpt/pdfToImages';
+import { getAllReceipts, updateReceipt } from './db-store';
+import { listTransactions, updateTransaction } from './transactions-store';
 
 // ─── Model configuration (env-driven; never hard-code) ────────────────────
 function getProvider(): string {
@@ -341,4 +343,35 @@ export async function matchReceiptToAmexTransaction(
     }
   }
   return best;
+}
+
+/**
+ * Reconcile the whole feed: match every unmatched receipt against unmatched
+ * Amex transactions and persist the links on both sides. Greedy by confidence;
+ * each Amex transaction is claimed at most once.
+ */
+export async function runAutoMatch(): Promise<{ scanned: number; matched: number }> {
+  const receipts = getAllReceipts({ matchStatus: 'unmatched' });
+  const txns = listTransactions({ matchStatus: 'unmatched' });
+  const claimed = new Set<string>();
+  let matched = 0;
+
+  for (const r of receipts) {
+    const candidates: AmexCandidate[] = txns
+      .filter((t) => !claimed.has(t.id))
+      .map((t) => ({ id: t.id, amount: t.amount, date: t.transaction_date, vendor: t.merchant_name }));
+
+    const result = await matchReceiptToAmexTransaction(r.amount, r.date, r.vendor, candidates);
+    if (result) {
+      claimed.add(result.id);
+      updateReceipt(r.id, { match_status: 'matched', amex_txn_id: result.id });
+      updateTransaction(result.id, {
+        match_status: 'matched',
+        matched_receipt_id: r.id,
+        match_score: Math.round(result.confidence * 100),
+      });
+      matched += 1;
+    }
+  }
+  return { scanned: receipts.length, matched };
 }

--- a/lib/receipts/reports-store.ts
+++ b/lib/receipts/reports-store.ts
@@ -1,0 +1,135 @@
+/**
+ * lib/receipts/reports-store.ts
+ *
+ * Expense reports: a bundle of receipts submitted together and moved through
+ * submitted → approved → closed. Receipts link to a report via receipts.report_id.
+ */
+
+import { randomUUID } from 'crypto';
+import { getDatabase } from '../db/client';
+import { getReceiptById, type Receipt } from './db-store';
+
+export type ReportStatus = 'submitted' | 'approved' | 'closed';
+
+export interface ExpenseReport {
+  id: string;
+  display_number: number;
+  submitted_by: string;
+  submitted_at: string;
+  status: ReportStatus;
+  approver_email: string | null;
+  approved_at: string | null;
+  closed_at: string | null;
+  total_amount: number;
+  expense_count: number;
+  notes: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function nextDisplayNumber(): number {
+  const db = getDatabase();
+  const row = db.prepare('SELECT MAX(display_number) AS n FROM expense_reports').get() as { n: number | null };
+  return (row?.n ?? 0) + 1;
+}
+
+export function listReports(status?: ReportStatus): ExpenseReport[] {
+  const db = getDatabase();
+  if (status) {
+    return db
+      .prepare('SELECT * FROM expense_reports WHERE status = ? ORDER BY datetime(submitted_at) DESC')
+      .all(status) as ExpenseReport[];
+  }
+  return db
+    .prepare('SELECT * FROM expense_reports ORDER BY datetime(submitted_at) DESC')
+    .all() as ExpenseReport[];
+}
+
+export function getReportStatusCounts(): Record<ReportStatus, number> {
+  const db = getDatabase();
+  const rows = db
+    .prepare('SELECT status, COUNT(*) AS n FROM expense_reports GROUP BY status')
+    .all() as Array<{ status: ReportStatus; n: number }>;
+  const counts: Record<ReportStatus, number> = { submitted: 0, approved: 0, closed: 0 };
+  for (const r of rows) if (r.status in counts) counts[r.status] = r.n;
+  return counts;
+}
+
+export function getReportById(id: string): (ExpenseReport & { receipts: Receipt[] }) | null {
+  const db = getDatabase();
+  const report = db.prepare('SELECT * FROM expense_reports WHERE id = ?').get(id) as
+    | ExpenseReport
+    | undefined;
+  if (!report) return null;
+  const receipts = db
+    .prepare('SELECT * FROM receipts WHERE report_id = ? ORDER BY datetime(created_at) DESC')
+    .all(id) as Receipt[];
+  return { ...report, receipts };
+}
+
+/**
+ * Create a report from a set of receipt IDs: stamps receipts.report_id and
+ * computes totals. Skips receipts that don't exist or are already on a report.
+ */
+export function createReport(data: {
+  submitted_by: string;
+  receiptIds: string[];
+  notes?: string;
+}): ExpenseReport & { receipts: Receipt[] } {
+  const db = getDatabase();
+  const now = nowIso();
+  const id = randomUUID();
+
+  const valid = (data.receiptIds || [])
+    .map((rid) => getReceiptById(rid))
+    .filter((r): r is Receipt => !!r && !r.report_id);
+
+  const total = valid.reduce((s, r) => s + (Number(r.amount) || 0), 0);
+
+  const tx = db.transaction(() => {
+    db.prepare(
+      `INSERT INTO expense_reports
+         (id, display_number, submitted_by, submitted_at, status, approver_email,
+          approved_at, closed_at, total_amount, expense_count, notes, created_at, updated_at)
+       VALUES (@id, @display_number, @submitted_by, @now, 'submitted', NULL,
+          NULL, NULL, @total, @count, @notes, @now, @now)`
+    ).run({
+      id,
+      display_number: nextDisplayNumber(),
+      submitted_by: data.submitted_by,
+      total: Math.round(total * 100) / 100,
+      count: valid.length,
+      notes: data.notes ?? '',
+      now,
+    });
+    const link = db.prepare('UPDATE receipts SET report_id = ?, updated_at = ? WHERE id = ?');
+    for (const r of valid) link.run(id, now, r.id);
+  });
+  tx();
+
+  return getReportById(id)!;
+}
+
+export function updateReportStatus(
+  id: string,
+  data: { status: ReportStatus; approver_email?: string }
+): (ExpenseReport & { receipts: Receipt[] }) | null {
+  const db = getDatabase();
+  const existing = getReportById(id);
+  if (!existing) return null;
+  const now = nowIso();
+  db.prepare(
+    `UPDATE expense_reports
+     SET status = @status,
+         approver_email = COALESCE(@approver_email, approver_email),
+         approved_at = CASE WHEN @status = 'approved' THEN @now ELSE approved_at END,
+         closed_at = CASE WHEN @status = 'closed' THEN @now ELSE closed_at END,
+         updated_at = @now
+     WHERE id = @id`
+  ).run({ id, status: data.status, approver_email: data.approver_email ?? null, now });
+  return getReportById(id);
+}

--- a/lib/receipts/reports-store.ts
+++ b/lib/receipts/reports-store.ts
@@ -23,6 +23,9 @@ export interface ExpenseReport {
   total_amount: number;
   expense_count: number;
   notes: string;
+  qbo_purchase_id: string | null;
+  qbo_exported_at: string | null;
+  qbo_export_error: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -131,5 +134,28 @@ export function updateReportStatus(
          updated_at = @now
      WHERE id = @id`
   ).run({ id, status: data.status, approver_email: data.approver_email ?? null, now });
+  return getReportById(id);
+}
+
+/** Record the outcome of a QBO export attempt. On success also closes the report. */
+export function setReportQboResult(
+  id: string,
+  result: { purchaseId?: string | null; error?: string | null }
+): (ExpenseReport & { receipts: Receipt[] }) | null {
+  const db = getDatabase();
+  if (!getReportById(id)) return null;
+  const now = nowIso();
+  if (result.purchaseId) {
+    db.prepare(
+      `UPDATE expense_reports
+       SET qbo_purchase_id = @pid, qbo_exported_at = @now, qbo_export_error = NULL,
+           status = 'closed', closed_at = @now, updated_at = @now
+       WHERE id = @id`
+    ).run({ id, pid: result.purchaseId, now });
+  } else {
+    db.prepare(
+      `UPDATE expense_reports SET qbo_export_error = @err, updated_at = @now WHERE id = @id`
+    ).run({ id, err: result.error ?? 'Unknown error', now });
+  }
   return getReportById(id);
 }

--- a/lib/receipts/transactions-store.ts
+++ b/lib/receipts/transactions-store.ts
@@ -1,0 +1,161 @@
+/**
+ * lib/receipts/transactions-store.ts
+ *
+ * Amex transaction feed for the receipts module. Rows arrive via statement
+ * import (CSV/XLSX) today; a Plaid sync can write the same shape later.
+ */
+
+import { randomUUID } from 'crypto';
+import { getDatabase } from '../db/client';
+
+export type TxnMatchStatus = 'unmatched' | 'matched' | 'needs_review';
+
+export interface AmexTransaction {
+  id: string;
+  transaction_date: string;
+  amount: number;
+  merchant_name: string;
+  description_raw: string;
+  category: string;
+  card_last4: string;
+  cardholder_name: string;
+  reference_number: string;
+  match_status: TxnMatchStatus;
+  matched_receipt_id: string | null;
+  match_score: number | null;
+  source: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TxnFilters {
+  matchStatus?: TxnMatchStatus;
+  cardLast4?: string;
+  search?: string;
+}
+
+export interface TxnStats {
+  total_count: number;
+  total_amount: number;
+  matched: number;
+  unmatched: number;
+  match_pct: number;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function listTransactions(filters: TxnFilters = {}): AmexTransaction[] {
+  const db = getDatabase();
+  const where: string[] = [];
+  const params: Record<string, unknown> = {};
+  if (filters.matchStatus) {
+    where.push('match_status = @matchStatus');
+    params.matchStatus = filters.matchStatus;
+  }
+  if (filters.cardLast4) {
+    where.push('card_last4 = @cardLast4');
+    params.cardLast4 = filters.cardLast4;
+  }
+  if (filters.search) {
+    where.push('(LOWER(merchant_name) LIKE @search OR LOWER(description_raw) LIKE @search)');
+    params.search = `%${filters.search.toLowerCase()}%`;
+  }
+  const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  return db
+    .prepare(`SELECT * FROM amex_transactions ${clause} ORDER BY date(transaction_date) DESC, created_at DESC`)
+    .all(params) as AmexTransaction[];
+}
+
+export function getTransactionById(id: string): AmexTransaction | null {
+  const db = getDatabase();
+  const row = db.prepare('SELECT * FROM amex_transactions WHERE id = ?').get(id) as
+    | AmexTransaction
+    | undefined;
+  return row ?? null;
+}
+
+/**
+ * Insert a batch of transactions. Relies on the unique dedupe index
+ * (transaction_date, amount, merchant_name, card_last4) to skip duplicates.
+ */
+export function bulkInsert(rows: Array<Partial<AmexTransaction>>): { inserted: number; skipped: number } {
+  const db = getDatabase();
+  const now = nowIso();
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO amex_transactions
+       (id, transaction_date, amount, merchant_name, description_raw, category,
+        card_last4, cardholder_name, reference_number, match_status,
+        matched_receipt_id, match_score, source, created_at, updated_at)
+     VALUES (@id, @transaction_date, @amount, @merchant_name, @description_raw, @category,
+        @card_last4, @cardholder_name, @reference_number, 'unmatched',
+        NULL, NULL, @source, @now, @now)`
+  );
+
+  let inserted = 0;
+  const insertMany = db.transaction((items: Array<Partial<AmexTransaction>>) => {
+    for (const r of items) {
+      const info = stmt.run({
+        id: randomUUID(),
+        transaction_date: r.transaction_date ?? '',
+        amount: typeof r.amount === 'number' ? r.amount : 0,
+        merchant_name: r.merchant_name ?? '',
+        description_raw: r.description_raw ?? '',
+        category: r.category ?? '',
+        card_last4: r.card_last4 ?? '',
+        cardholder_name: r.cardholder_name ?? '',
+        reference_number: r.reference_number ?? '',
+        source: r.source ?? 'import',
+        now,
+      });
+      inserted += info.changes;
+    }
+  });
+  insertMany(rows);
+  return { inserted, skipped: rows.length - inserted };
+}
+
+export function updateTransaction(id: string, data: Partial<AmexTransaction>): AmexTransaction | null {
+  const db = getDatabase();
+  const existing = getTransactionById(id);
+  if (!existing) return null;
+  const allowed: Array<keyof AmexTransaction> = [
+    'transaction_date', 'amount', 'merchant_name', 'description_raw', 'category',
+    'card_last4', 'cardholder_name', 'reference_number', 'match_status',
+    'matched_receipt_id', 'match_score',
+  ];
+  const sets: string[] = [];
+  const params: Record<string, unknown> = { id };
+  for (const f of allowed) {
+    if (Object.prototype.hasOwnProperty.call(data, f)) {
+      sets.push(`${f} = @${f}`);
+      params[f] = (data as Record<string, unknown>)[f];
+    }
+  }
+  if (!sets.length) return existing;
+  sets.push('updated_at = @updated_at');
+  params.updated_at = nowIso();
+  db.prepare(`UPDATE amex_transactions SET ${sets.join(', ')} WHERE id = @id`).run(params);
+  return getTransactionById(id);
+}
+
+export function deleteTransaction(id: string): boolean {
+  const db = getDatabase();
+  return db.prepare('DELETE FROM amex_transactions WHERE id = ?').run(id).changes > 0;
+}
+
+export function getTransactionStats(filters: TxnFilters = {}): TxnStats {
+  const txns = listTransactions(filters);
+  const total_count = txns.length;
+  const total_amount = txns.reduce((s, t) => s + (Number(t.amount) || 0), 0);
+  const matched = txns.filter((t) => t.match_status === 'matched').length;
+  const unmatched = txns.filter((t) => t.match_status === 'unmatched').length;
+  return {
+    total_count,
+    total_amount: Math.round(total_amount * 100) / 100,
+    matched,
+    unmatched,
+    match_pct: total_count ? Math.round((matched / total_count) * 100) : 0,
+  };
+}

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -4,7 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import NavBar from './NavBar';
 import { InvoiceClickProvider } from '../context/InvoiceClickContext';
 import { InvoiceDataProvider, useInvoiceData } from '../context/InvoiceDataContext';
-import { UserRoleProvider, useUserRole } from '../context/UserRoleContext';
+import { UserRoleProvider } from '../context/UserRoleContext';
 import FilterPanel from './FilterPanel.jsx'
 import FeedbackButton from './FeedbackButton';
 
@@ -21,6 +21,11 @@ export default function AppLayout({ children }) {
   // Determine if this is an auth page or vendor onboarding success page
   const isAuthPage = pathname === '/LoginPage' || pathname === '/SignupPage';
   const isVendorOnboardingSuccess = pathname === '/VendorOnboardingSuccess';
+  // Credit Card Receipts renders its own full-height shell (sidebar + topbar),
+  // so suppress the shared top NavBar/FilterPanel and chrome on that route.
+  const isReceiptsPage = pathname.startsWith('/CreditCardReceiptsPage');
+  // Routes that render full-bleed without the shared AP chrome.
+  const isChromeless = isAuthPage || isVendorOnboardingSuccess || isReceiptsPage;
 
   useEffect(() => {
     const path = pathname.split('/')[1] || 'ForMePage';
@@ -105,8 +110,8 @@ export default function AppLayout({ children }) {
   // Render content with or without InvoiceClickProvider based on page type
   const content = (
     <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
-      {/* Render NavBar only on non-auth and non-vendor-onboarding pages */}
-      {!isAuthPage && !isVendorOnboardingSuccess && (
+      {/* Render NavBar only on pages that use the shared AP chrome */}
+      {!isChromeless && (
         <NavBar
           currentPage={currentPage}
           onChangePage={handleChangePage}
@@ -115,8 +120,8 @@ export default function AppLayout({ children }) {
           onLogout={handleLogout}
         />
       )}
-      {/* Render FilterPanel only on non-auth and non-vendor-onboarding pages */}
-      {!isAuthPage && !isVendorOnboardingSuccess && (
+      {/* Render FilterPanel only on pages that use the shared AP chrome */}
+      {!isChromeless && (
         <FilterPanelWrapper
           isOpen={isFilterOpen}
           onClose={() => setIsFilterOpen(false)}
@@ -138,7 +143,7 @@ export default function AppLayout({ children }) {
           }}
         />
       )}
-      <main style={{ flex: 1, padding: (isAuthPage || isVendorOnboardingSuccess) ? '0' : '20px' }}>
+      <main style={{ flex: 1, padding: isChromeless ? '0' : '20px' }}>
         {React.isValidElement(children) ? React.cloneElement(children, { filters }) : children}
       </main>
       
@@ -147,8 +152,8 @@ export default function AppLayout({ children }) {
     </div>
   );
 
-  // Only wrap with InvoiceClickProvider on non-auth and non-vendor-onboarding pages
-  if (isAuthPage || isVendorOnboardingSuccess) {
+  // Only wrap with InvoiceClickProvider on pages that use the shared AP chrome
+  if (isChromeless) {
     return content;
   }
 

--- a/src/ui-pages/CreditCardReceiptsPage.jsx
+++ b/src/ui-pages/CreditCardReceiptsPage.jsx
@@ -1,104 +1,41 @@
 /**
  * CreditCardReceiptsPage.jsx
  *
- * Credit Card Receipts module UI — replicates the receipt-agent Flask app's
- * "Sage" design (navy sidebar + topbar + Pacific-blue accents). Renders its own
- * full-height shell; AppLayout suppresses the shared pcs-ui top nav on this route.
+ * Credit Card Receipts module — replicates the receipt-agent Flask app's "Sage"
+ * design (navy sidebar + topbar). This file is the shell + router; each nav item
+ * renders a view component from ./receipts/*. AppLayout suppresses the shared
+ * pcs-ui top nav on this route so the module owns its full-height chrome.
  *
- * Styling: ./CreditCardReceiptsPage.module.css (scoped — no global bleed).
- *
- * Backed by:
- *   GET    /api/receipts            → { receipts, stats }   (filters: status, mine, q)
- *   POST   /api/receipts            → manual create (JSON) OR upload (multipart file)
- *   GET    /api/receipts/:id        → one receipt
- *   PATCH  /api/receipts/:id        → update fields, or { action:'match', transactions }
- *   DELETE /api/receipts/:id        → delete
- *   GET    /api/receipts/:id/file   → stream the stored receipt image/PDF
+ * Styling: ./CreditCardReceiptsPage.module.css (scoped via CSS Modules).
  */
 
 'use client';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import styles from './CreditCardReceiptsPage.module.css';
+import { currentEmail } from './receipts/shared';
+import ExpensesView from './receipts/ExpensesView';
+import TransactionsView from './receipts/TransactionsView';
+import CardsView from './receipts/CardsView';
+import ReportsView from './receipts/ReportsView';
+import DashboardView from './receipts/DashboardView';
+import TasksView from './receipts/TasksView';
+import { IntegrationsView, SettingsView, AIAssistantView } from './receipts/MiscViews';
 
-// ─── helpers ─────────────────────────────────────────────────────────────
-function money(n) {
-  const v = Number(n) || 0;
-  return v.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
-}
-
-function fmtDate(d) {
-  if (!d) return '—';
-  const parsed = new Date(d);
-  if (Number.isNaN(parsed.getTime())) return d;
-  return parsed.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', year: '2-digit' });
-}
-
-// Forward the current query string (e.g. ?email=...) so API auth works without cookies.
-function apiUrl(pathname, extra = {}) {
-  const params =
-    typeof window !== 'undefined'
-      ? new URLSearchParams(window.location.search)
-      : new URLSearchParams();
-  Object.entries(extra).forEach(([k, v]) => {
-    if (v === undefined || v === null || v === '') params.delete(k);
-    else params.set(k, String(v));
-  });
-  const qs = params.toString();
-  return `${pathname}${qs ? `?${qs}` : ''}`;
-}
-
-function currentEmail() {
-  if (typeof window === 'undefined') return '';
-  return new URLSearchParams(window.location.search).get('email') || '';
-}
-
-const STATUS_TABS = [
-  { key: 'all', label: 'All' },
-  { key: 'unmatched', label: 'Unmatched' },
-  { key: 'matched', label: 'Matched' },
-  { key: 'disputed', label: 'Disputed' },
-];
-
-// Sidebar nav mirrors the Flask app. "Business Expenses" is the live receipts
-// view; "Dashboard" shows the tiles. The rest are shown for parity and render a
-// placeholder (those areas aren't part of the receipts module in pcs-ui yet).
 const NAV = [
+  { key: 'tasks', icon: '📋', label: 'Tasks' },
   { key: 'dashboard', icon: '📊', label: 'Dashboard' },
   { key: 'expenses', icon: '🧾', label: 'Business Expenses' },
-  { key: 'reports', icon: '📑', label: 'Expense Reports', placeholder: true },
-  { key: 'transactions', icon: '💳', label: 'Transactions', placeholder: true },
-  { key: 'cards', icon: '🗂️', label: 'Manage Cards', placeholder: true },
-  { key: 'integrations', icon: '🔌', label: 'Integrations', placeholder: true },
-  { key: 'settings', icon: '⚙️', label: 'Settings', placeholder: true },
+  { key: 'transactions', icon: '💳', label: 'Transactions' },
+  { key: 'cards', icon: '🗂️', label: 'Manage Cards' },
+  { key: 'reports', icon: '📑', label: 'Expense Reports' },
+  { key: 'integrations', icon: '🔌', label: 'Integrations' },
+  { key: 'ai', icon: '✨', label: 'AI Assistant' },
+  { key: 'settings', icon: '⚙️', label: 'Settings' },
 ];
-
-const EMPTY_FORM = {
-  vendor: '',
-  amount: '',
-  date: '',
-  gl_account: '',
-  location: '',
-  card_last4: '',
-  notes: '',
-};
 
 export default function CreditCardReceiptsPage() {
   const [view, setView] = useState('expenses');
-  const [receipts, setReceipts] = useState([]);
-  const [stats, setStats] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [mineOnly, setMineOnly] = useState(false);
-  const [search, setSearch] = useState('');
   const [toast, setToast] = useState(null);
-
-  const [showManual, setShowManual] = useState(false);
-  const [form, setForm] = useState(EMPTY_FORM);
-  const [saving, setSaving] = useState(false);
-  const [uploading, setUploading] = useState(false);
-
-  const [selected, setSelected] = useState(null);
 
   const email = currentEmail();
   const avatarInitial = (email ? email[0] : 'U').toUpperCase();
@@ -108,116 +45,24 @@ export default function CreditCardReceiptsPage() {
     setTimeout(() => setToast(null), 3500);
   }, []);
 
-  const load = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const res = await fetch(
-        apiUrl('/api/receipts', {
-          status: statusFilter === 'all' ? '' : statusFilter,
-          mine: mineOnly ? '1' : '',
-          q: search.trim(),
-        }),
-        { cache: 'no-store', credentials: 'include' }
-      );
-      if (!res.ok) throw new Error(`Failed to load receipts (HTTP ${res.status})`);
-      const data = await res.json();
-      setReceipts(Array.isArray(data.receipts) ? data.receipts : []);
-      setStats(data.stats || null);
-    } catch (e) {
-      setError(e.message || 'Failed to load receipts');
-    } finally {
-      setLoading(false);
-    }
-  }, [statusFilter, mineOnly, search]);
+  const goTo = useCallback((key) => setView(key), []);
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  const activeNav = NAV.find((n) => n.key === view) || NAV[2];
 
-  // ─── actions ──────────────────────────────────────────────────────────
-  const handleManualSave = async () => {
-    if (!form.vendor.trim()) return flash('Vendor is required', 'error');
-    const amount = parseFloat(form.amount);
-    if (!Number.isFinite(amount) || amount < 0) return flash('Enter a valid amount', 'error');
-    try {
-      setSaving(true);
-      const res = await fetch(apiUrl('/api/receipts'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ ...form, amount }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Create failed');
-      flash('Receipt added', 'success');
-      setShowManual(false);
-      setForm(EMPTY_FORM);
-      load();
-    } catch (e) {
-      flash(e.message, 'error');
-    } finally {
-      setSaving(false);
+  const renderView = () => {
+    switch (view) {
+      case 'tasks': return <TasksView flash={flash} goTo={goTo} />;
+      case 'dashboard': return <DashboardView flash={flash} />;
+      case 'expenses': return <ExpensesView flash={flash} />;
+      case 'transactions': return <TransactionsView flash={flash} />;
+      case 'cards': return <CardsView flash={flash} />;
+      case 'reports': return <ReportsView flash={flash} />;
+      case 'integrations': return <IntegrationsView />;
+      case 'ai': return <AIAssistantView flash={flash} />;
+      case 'settings': return <SettingsView />;
+      default: return <ExpensesView flash={flash} />;
     }
   };
-
-  const handleUpload = async (file) => {
-    if (!file) return;
-    try {
-      setUploading(true);
-      const fd = new FormData();
-      fd.append('file', file);
-      const res = await fetch(apiUrl('/api/receipts'), {
-        method: 'POST',
-        credentials: 'include',
-        body: fd,
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Upload failed');
-      if (data.parseError) {
-        flash(`Uploaded. AI parse unavailable — fill fields manually.`, 'info');
-      } else {
-        flash('Uploaded and parsed', 'success');
-      }
-      load();
-      if (data.receipt) setSelected(data.receipt);
-    } catch (e) {
-      flash(e.message, 'error');
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handlePatch = async (id, patch) => {
-    const res = await fetch(apiUrl(`/api/receipts/${id}`), {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify(patch),
-    });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || 'Update failed');
-    return data.receipt;
-  };
-
-  const handleDelete = async (id) => {
-    if (typeof window !== 'undefined' && !window.confirm('Delete this receipt?')) return;
-    try {
-      const res = await fetch(apiUrl(`/api/receipts/${id}`), {
-        method: 'DELETE',
-        credentials: 'include',
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Delete failed');
-      flash('Receipt deleted', 'success');
-      setSelected(null);
-      load();
-    } catch (e) {
-      flash(e.message, 'error');
-    }
-  };
-
-  const activeNav = NAV.find((n) => n.key === view) || NAV[1];
 
   return (
     <div className={styles.shell}>
@@ -239,9 +84,6 @@ export default function CreditCardReceiptsPage() {
             >
               <span className={styles.navIcon}>{item.icon}</span>
               <span className={styles.navLabel}>{item.label}</span>
-              {item.key === 'expenses' && stats && stats.unmatched > 0 ? (
-                <span className={styles.navBadge}>{stats.unmatched}</span>
-              ) : null}
             </button>
           ))}
         </nav>
@@ -264,61 +106,8 @@ export default function CreditCardReceiptsPage() {
           </div>
         </header>
 
-        <main className={styles.content}>
-          {view === 'expenses' && (
-            <ExpensesView
-              stats={stats}
-              receipts={receipts}
-              loading={loading}
-              error={error}
-              statusFilter={statusFilter}
-              setStatusFilter={setStatusFilter}
-              mineOnly={mineOnly}
-              setMineOnly={setMineOnly}
-              search={search}
-              setSearch={setSearch}
-              uploading={uploading}
-              onUpload={handleUpload}
-              onAdd={() => {
-                setForm(EMPTY_FORM);
-                setShowManual(true);
-              }}
-              onRowClick={(r) => setSelected(r)}
-              onDelete={handleDelete}
-            />
-          )}
-
-          {view === 'dashboard' && <DashboardView stats={stats} />}
-
-          {activeNav.placeholder && (
-            <Placeholder label={activeNav.label} />
-          )}
-        </main>
+        <main className={styles.content}>{renderView()}</main>
       </div>
-
-      {showManual && (
-        <ManualEntryModal
-          form={form}
-          setForm={setForm}
-          saving={saving}
-          onSave={handleManualSave}
-          onClose={() => setShowManual(false)}
-        />
-      )}
-
-      {selected && (
-        <ReceiptDrawer
-          receipt={selected}
-          onClose={() => setSelected(null)}
-          onPatch={handlePatch}
-          onDelete={handleDelete}
-          onSaved={(updated) => {
-            setSelected(updated);
-            load();
-          }}
-          flash={flash}
-        />
-      )}
 
       {toast && (
         <div
@@ -329,394 +118,6 @@ export default function CreditCardReceiptsPage() {
           {toast.message}
         </div>
       )}
-    </div>
-  );
-}
-
-// ============================================================================
-// Views
-// ============================================================================
-
-function ExpensesView({
-  stats, receipts, loading, error,
-  statusFilter, setStatusFilter, mineOnly, setMineOnly, search, setSearch,
-  uploading, onUpload, onAdd, onRowClick, onDelete,
-}) {
-  return (
-    <>
-      <div className={styles.pageHeader}>
-        <div>
-          <div className={styles.pageTitle}>Business Expenses</div>
-          <div className={styles.pageSubtitle}>
-            Submit, track, and reconcile credit card receipts against Amex transactions.
-          </div>
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <label className={`${styles.btn} ${styles.btnSecondary} ${styles.uploadLabel}`} style={{ cursor: uploading ? 'wait' : 'pointer' }}>
-            <span>⬆</span>
-            {uploading ? 'Uploading…' : 'Upload receipt'}
-            <input
-              type="file"
-              accept="image/*,application/pdf"
-              style={{ display: 'none' }}
-              disabled={uploading}
-              onChange={(e) => {
-                const f = e.target.files?.[0];
-                e.target.value = '';
-                onUpload(f);
-              }}
-            />
-          </label>
-          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={onAdd}>
-            <span>＋</span> Add receipt
-          </button>
-        </div>
-      </div>
-
-      <SummaryTiles stats={stats} />
-
-      <div className={styles.tableWrapper}>
-        <div className={styles.tableToolbar}>
-          <div className={styles.tableFilters}>
-            {STATUS_TABS.map((tab) => (
-              <button
-                key={tab.key}
-                onClick={() => setStatusFilter(tab.key)}
-                className={`${styles.btn} ${statusFilter === tab.key ? styles.btnPrimary : styles.btnGhost}`}
-                style={{ padding: '5px 12px', fontSize: 12 }}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-          <div className={styles.tableFilters}>
-            <input
-              className={styles.formInput}
-              style={{ width: 220 }}
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search vendor, GL, notes…"
-            />
-            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--color-text-muted)', cursor: 'pointer' }}>
-              <input type="checkbox" checked={mineOnly} onChange={(e) => setMineOnly(e.target.checked)} />
-              Mine only
-            </label>
-          </div>
-        </div>
-
-        {error ? (
-          <div className={styles.emptyState} style={{ color: 'var(--color-danger)' }}>{error}</div>
-        ) : loading ? (
-          <div className={styles.emptyState}>Loading receipts…</div>
-        ) : receipts.length === 0 ? (
-          <div className={styles.emptyState}>
-            <div className={styles.emptyIcon}>🧾</div>
-            <div className={styles.emptyTitle}>No receipts yet</div>
-            <div className={styles.emptyMessage}>
-              Upload a receipt image/PDF or add one manually to get started.
-            </div>
-          </div>
-        ) : (
-          <table className={styles.dataTable}>
-            <thead>
-              <tr>
-                <th>Receipt</th>
-                <th>Date</th>
-                <th>Vendor</th>
-                <th className={styles.right}>Amount</th>
-                <th>GL account</th>
-                <th>Location</th>
-                <th>Card</th>
-                <th>Status</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {receipts.map((r) => (
-                <tr key={r.id} onClick={() => onRowClick(r)}>
-                  <td>
-                    {r.image_path ? <span title="Has file">🧾</span> : <span style={{ opacity: 0.3 }} title="No file">○</span>}
-                  </td>
-                  <td>{fmtDate(r.date)}</td>
-                  <td style={{ fontWeight: 500 }}>
-                    {r.vendor || <span style={{ color: 'var(--color-text-subtle)' }}>Unknown</span>}
-                  </td>
-                  <td className={`${styles.right} ${styles.money}`}>{money(r.amount)}</td>
-                  <td style={{ color: 'var(--color-text-muted)' }}>{r.gl_account || '—'}</td>
-                  <td style={{ color: 'var(--color-text-muted)' }}>{r.location || '—'}</td>
-                  <td style={{ color: 'var(--color-text-muted)' }}>{r.card_last4 ? `•••• ${r.card_last4}` : '—'}</td>
-                  <td><StatusBadge status={r.match_status} /></td>
-                  <td className={styles.right}>
-                    <button
-                      title="Delete"
-                      className={styles.iconBtn}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDelete(r.id);
-                      }}
-                    >
-                      🗑
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
-    </>
-  );
-}
-
-function DashboardView({ stats }) {
-  return (
-    <>
-      <div className={styles.pageHeader}>
-        <div>
-          <div className={styles.pageTitle}>Dashboard</div>
-          <div className={styles.pageSubtitle}>Receipt reconciliation overview.</div>
-        </div>
-      </div>
-      <SummaryTiles stats={stats} />
-    </>
-  );
-}
-
-function Placeholder({ label }) {
-  return (
-    <>
-      <div className={styles.pageHeader}>
-        <div className={styles.pageTitle}>{label}</div>
-      </div>
-      <div className={styles.tableWrapper}>
-        <div className={styles.emptyState}>
-          <div className={styles.emptyIcon}>🚧</div>
-          <div className={styles.emptyTitle}>{label} isn’t part of the receipts module yet</div>
-          <div className={styles.emptyMessage}>
-            This view exists in the standalone receipt-agent app. Plaid/Amex feed, expense
-            reports, and QBO export are planned for a later phase.
-          </div>
-        </div>
-      </div>
-    </>
-  );
-}
-
-function SummaryTiles({ stats }) {
-  const tiles = [
-    { label: 'Total receipts', value: stats ? stats.total_count : '—' },
-    { label: 'Total amount', value: stats ? money(stats.total_amount) : '—' },
-    { label: 'Matched', value: stats ? stats.matched : '—', suffix: stats ? `${stats.match_pct}% of total` : '' },
-    { label: 'Unmatched', value: stats ? stats.unmatched : '—' },
-    { label: 'Disputed', value: stats ? stats.disputed : '—' },
-  ];
-  return (
-    <div className={styles.summaryTiles}>
-      {tiles.map((t) => (
-        <div key={t.label} className={styles.summaryTile}>
-          <div className={styles.tileLabel}>{t.label}</div>
-          <div className={styles.tileValue}>{t.value}</div>
-          {t.suffix ? <div className={styles.tileSuffix}>{t.suffix}</div> : null}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function StatusBadge({ status }) {
-  const cls =
-    status === 'matched' ? styles.badgeMatched : status === 'disputed' ? styles.badgeDisputed : styles.badgeUnmatched;
-  return <span className={`${styles.badge} ${cls}`}>{status || 'unmatched'}</span>;
-}
-
-// ============================================================================
-// Modals
-// ============================================================================
-
-function ManualEntryModal({ form, setForm, saving, onSave, onClose }) {
-  const field = (label, key, props = {}) => (
-    <div className={styles.formGroup}>
-      <label className={styles.formLabel}>{label}</label>
-      <input
-        className={styles.formInput}
-        value={form[key]}
-        onChange={(e) => setForm({ ...form, [key]: e.target.value })}
-        {...props}
-      />
-    </div>
-  );
-  return (
-    <Backdrop onClose={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.modalHeader}>
-          <div className={styles.modalTitle}>Add receipt</div>
-          <button className={styles.modalClose} onClick={onClose}>×</button>
-        </div>
-        <div className={styles.modalBody}>
-          {field('Vendor *', 'vendor')}
-          <div className={styles.formRow}>
-            {field('Amount *', 'amount', { type: 'number', step: '0.01', placeholder: '0.00' })}
-            {field('Date', 'date', { type: 'date' })}
-          </div>
-          {field('GL account', 'gl_account', { placeholder: 'Auto-categorized if left blank' })}
-          <div className={styles.formRow}>
-            {field('Location', 'location')}
-            {field('Card last 4', 'card_last4', { maxLength: 4 })}
-          </div>
-          {field('Notes', 'notes')}
-        </div>
-        <div className={styles.modalFooter}>
-          <button className={`${styles.btn} ${styles.btnGhost}`} onClick={onClose} disabled={saving}>Cancel</button>
-          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={onSave} disabled={saving}>
-            {saving ? 'Saving…' : 'Save receipt'}
-          </button>
-        </div>
-      </div>
-    </Backdrop>
-  );
-}
-
-function ReceiptDrawer({ receipt, onClose, onPatch, onDelete, onSaved, flash }) {
-  const [draft, setDraft] = useState(receipt);
-  const [savingField, setSavingField] = useState(false);
-  const [matching, setMatching] = useState(false);
-
-  useEffect(() => {
-    setDraft(receipt);
-  }, [receipt]);
-
-  const isPdf = (receipt.image_path || '').toLowerCase().endsWith('.pdf');
-  const fileUrl = receipt.image_path ? apiUrl(`/api/receipts/${receipt.id}/file`) : null;
-
-  const saveFields = async () => {
-    try {
-      setSavingField(true);
-      const updated = await onPatch(receipt.id, {
-        vendor: draft.vendor,
-        amount: parseFloat(draft.amount) || 0,
-        date: draft.date,
-        gl_account: draft.gl_account,
-        location: draft.location,
-        card_last4: draft.card_last4,
-        notes: draft.notes,
-        match_status: draft.match_status,
-      });
-      flash('Saved', 'success');
-      onSaved(updated);
-    } catch (e) {
-      flash(e.message, 'error');
-    } finally {
-      setSavingField(false);
-    }
-  };
-
-  // No Amex feed table exists in pcs-ui yet (Plaid integration is external/planned).
-  // The matcher runs against candidates the caller supplies; with none available it
-  // returns unmatched. Reviewers can still set the status manually below.
-  const runMatch = async () => {
-    try {
-      setMatching(true);
-      const updated = await onPatch(receipt.id, { action: 'match', transactions: [] });
-      flash('No Amex candidates available — connect Plaid to enable auto-match.', 'info');
-      onSaved(updated);
-    } catch (e) {
-      flash(e.message, 'error');
-    } finally {
-      setMatching(false);
-    }
-  };
-
-  const field = (label, key, props = {}) => (
-    <div className={styles.formGroup}>
-      <label className={styles.formLabel}>{label}</label>
-      <input
-        className={styles.formInput}
-        value={draft[key] ?? ''}
-        onChange={(e) => setDraft({ ...draft, [key]: e.target.value })}
-        {...props}
-      />
-    </div>
-  );
-
-  return (
-    <Backdrop onClose={onClose}>
-      <div className={styles.drawer} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.modalHeader}>
-          <div className={styles.modalTitle}>{receipt.vendor || 'Receipt detail'}</div>
-          <button className={styles.modalClose} onClick={onClose}>×</button>
-        </div>
-        <div className={styles.modalBody}>
-          <div className={styles.popoutGrid}>
-            {/* Left: editable fields */}
-            <div>
-              {field('Vendor', 'vendor')}
-              <div className={styles.formRow}>
-                {field('Amount', 'amount', { type: 'number', step: '0.01' })}
-                {field('Date', 'date', { type: 'date' })}
-              </div>
-              {field('GL account', 'gl_account')}
-              <div className={styles.formRow}>
-                {field('Location', 'location')}
-                {field('Card last 4', 'card_last4', { maxLength: 4 })}
-              </div>
-              <div className={styles.formGroup}>
-                <label className={styles.formLabel}>Status</label>
-                <select
-                  className={styles.formSelect}
-                  value={draft.match_status}
-                  onChange={(e) => setDraft({ ...draft, match_status: e.target.value })}
-                >
-                  <option value="unmatched">Unmatched</option>
-                  <option value="matched">Matched</option>
-                  <option value="disputed">Disputed</option>
-                </select>
-              </div>
-              {field('Notes', 'notes')}
-              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={saveFields} disabled={savingField}>
-                  {savingField ? 'Saving…' : 'Save'}
-                </button>
-                <button className={`${styles.btn} ${styles.btnSecondary}`} onClick={runMatch} disabled={matching}>
-                  {matching ? 'Matching…' : 'Find Amex match'}
-                </button>
-                <button className={`${styles.btn} ${styles.btnDanger}`} onClick={() => onDelete(receipt.id)}>
-                  Delete
-                </button>
-              </div>
-            </div>
-
-            {/* Right: receipt viewer */}
-            <div>
-              <div className={styles.amexCard}>
-                <div className={styles.amexLabel}>Match status</div>
-                <StatusBadge status={receipt.match_status} />
-                {receipt.amex_txn_id ? (
-                  <div style={{ marginTop: 8, fontSize: 12, color: 'var(--color-text-muted)' }}>
-                    Amex txn: {receipt.amex_txn_id}
-                  </div>
-                ) : null}
-              </div>
-              {!fileUrl ? (
-                <div className={styles.receiptViewerEmpty}>No file attached</div>
-              ) : isPdf ? (
-                <iframe title="receipt" src={fileUrl} className={styles.receiptViewer} style={{ width: '100%', height: 420 }} />
-              ) : (
-                <div className={styles.receiptViewer}>
-                  <img src={fileUrl} alt="receipt" style={{ width: '100%', display: 'block' }} />
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    </Backdrop>
-  );
-}
-
-function Backdrop({ children, onClose }) {
-  return (
-    <div className={styles.modalBackdrop} onClick={onClose}>
-      {children}
     </div>
   );
 }

--- a/src/ui-pages/CreditCardReceiptsPage.jsx
+++ b/src/ui-pages/CreditCardReceiptsPage.jsx
@@ -57,7 +57,7 @@ export default function CreditCardReceiptsPage() {
       case 'transactions': return <TransactionsView flash={flash} />;
       case 'cards': return <CardsView flash={flash} />;
       case 'reports': return <ReportsView flash={flash} />;
-      case 'integrations': return <IntegrationsView />;
+      case 'integrations': return <IntegrationsView flash={flash} />;
       case 'ai': return <AIAssistantView flash={flash} />;
       case 'settings': return <SettingsView />;
       default: return <ExpensesView flash={flash} />;

--- a/src/ui-pages/CreditCardReceiptsPage.jsx
+++ b/src/ui-pages/CreditCardReceiptsPage.jsx
@@ -1,8 +1,11 @@
 /**
  * CreditCardReceiptsPage.jsx
  *
- * Credit Card Receipts module UI. Reached via the "Credit Card Receipts" button
- * in the top nav; sits inside the shared PCS AI layout (NavBar, auth, providers).
+ * Credit Card Receipts module UI — replicates the receipt-agent Flask app's
+ * "Sage" design (navy sidebar + topbar + Pacific-blue accents). Renders its own
+ * full-height shell; AppLayout suppresses the shared pcs-ui top nav on this route.
+ *
+ * Styling: ./CreditCardReceiptsPage.module.css (scoped — no global bleed).
  *
  * Backed by:
  *   GET    /api/receipts            → { receipts, stats }   (filters: status, mine, q)
@@ -11,26 +14,11 @@
  *   PATCH  /api/receipts/:id        → update fields, or { action:'match', transactions }
  *   DELETE /api/receipts/:id        → delete
  *   GET    /api/receipts/:id/file   → stream the stored receipt image/PDF
- *
- * Styling matches the rest of the app (inline styles, no Tailwind):
- *   primary #357ab2 · body 14px · title 24px · pills 9999px · cards 8px
  */
 
 'use client';
 import React, { useCallback, useEffect, useState } from 'react';
-
-// ─── style tokens ──────────────────────────────────────────────────────────
-const BLUE = '#357ab2';
-const MUTED = '#6b7280';
-const FAINT = '#9ca3af';
-const BORDER = '#e5e7eb';
-const BORDER_BLUE = '#c8dff0';
-
-const STATUS_COLORS = {
-  matched: { bg: '#e7f6ec', fg: '#1b7f3b' },
-  unmatched: { bg: '#fef3e2', fg: '#b9770e' },
-  disputed: { bg: '#fdecec', fg: '#c0392b' },
-};
+import styles from './CreditCardReceiptsPage.module.css';
 
 // ─── helpers ─────────────────────────────────────────────────────────────
 function money(n) {
@@ -59,11 +47,29 @@ function apiUrl(pathname, extra = {}) {
   return `${pathname}${qs ? `?${qs}` : ''}`;
 }
 
+function currentEmail() {
+  if (typeof window === 'undefined') return '';
+  return new URLSearchParams(window.location.search).get('email') || '';
+}
+
 const STATUS_TABS = [
   { key: 'all', label: 'All' },
   { key: 'unmatched', label: 'Unmatched' },
   { key: 'matched', label: 'Matched' },
   { key: 'disputed', label: 'Disputed' },
+];
+
+// Sidebar nav mirrors the Flask app. "Business Expenses" is the live receipts
+// view; "Dashboard" shows the tiles. The rest are shown for parity and render a
+// placeholder (those areas aren't part of the receipts module in pcs-ui yet).
+const NAV = [
+  { key: 'dashboard', icon: '📊', label: 'Dashboard' },
+  { key: 'expenses', icon: '🧾', label: 'Business Expenses' },
+  { key: 'reports', icon: '📑', label: 'Expense Reports', placeholder: true },
+  { key: 'transactions', icon: '💳', label: 'Transactions', placeholder: true },
+  { key: 'cards', icon: '🗂️', label: 'Manage Cards', placeholder: true },
+  { key: 'integrations', icon: '🔌', label: 'Integrations', placeholder: true },
+  { key: 'settings', icon: '⚙️', label: 'Settings', placeholder: true },
 ];
 
 const EMPTY_FORM = {
@@ -77,6 +83,7 @@ const EMPTY_FORM = {
 };
 
 export default function CreditCardReceiptsPage() {
+  const [view, setView] = useState('expenses');
   const [receipts, setReceipts] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -91,7 +98,10 @@ export default function CreditCardReceiptsPage() {
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
 
-  const [selected, setSelected] = useState(null); // receipt being viewed in drawer
+  const [selected, setSelected] = useState(null);
+
+  const email = currentEmail();
+  const avatarInitial = (email ? email[0] : 'U').toUpperCase();
 
   const flash = useCallback((message, variant = 'info') => {
     setToast({ message, variant });
@@ -165,7 +175,7 @@ export default function CreditCardReceiptsPage() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Upload failed');
       if (data.parseError) {
-        flash(`Uploaded. AI parse unavailable (${data.parseError}) — fill fields manually.`, 'info');
+        flash(`Uploaded. AI parse unavailable — fill fields manually.`, 'info');
       } else {
         flash('Uploaded and parsed', 'success');
       }
@@ -207,41 +217,84 @@ export default function CreditCardReceiptsPage() {
     }
   };
 
-  // ─── render ───────────────────────────────────────────────────────────
+  const activeNav = NAV.find((n) => n.key === view) || NAV[1];
+
   return (
-    <div style={{ padding: '32px', maxWidth: '1200px', margin: '0 auto' }}>
-      <PageHeader
-        onAdd={() => {
-          setForm(EMPTY_FORM);
-          setShowManual(true);
-        }}
-        onUpload={handleUpload}
-        uploading={uploading}
-      />
-
-      <SummaryTiles stats={stats} />
-
-      <Toolbar
-        statusFilter={statusFilter}
-        setStatusFilter={setStatusFilter}
-        mineOnly={mineOnly}
-        setMineOnly={setMineOnly}
-        search={search}
-        setSearch={setSearch}
-      />
-
-      {error && (
-        <div style={{ ...cardStyle, borderColor: '#f3c6c6', color: '#c0392b', marginTop: 12 }}>
-          {error}
+    <div className={styles.shell}>
+      {/* ─── Sidebar ─────────────────────────────────────────── */}
+      <aside className={styles.sidebar}>
+        <div className={styles.sidebarHeader}>
+          <div className={styles.logo}>PC</div>
+          <div className={styles.brand}>
+            <div className={styles.brandName}>PC SMILES</div>
+            <div className={styles.brandProduct}>Receipts</div>
+          </div>
         </div>
-      )}
+        <nav className={styles.nav}>
+          {NAV.map((item) => (
+            <button
+              key={item.key}
+              className={`${styles.navItem} ${view === item.key ? styles.navItemActive : ''}`}
+              onClick={() => setView(item.key)}
+            >
+              <span className={styles.navIcon}>{item.icon}</span>
+              <span className={styles.navLabel}>{item.label}</span>
+              {item.key === 'expenses' && stats && stats.unmatched > 0 ? (
+                <span className={styles.navBadge}>{stats.unmatched}</span>
+              ) : null}
+            </button>
+          ))}
+        </nav>
+        <div className={styles.sidebarFooter}>
+          Pacific Crest Smiles Dental, LLC
+          <br />
+          <span style={{ opacity: 0.6 }}>Receipts module</span>
+        </div>
+      </aside>
 
-      <ReceiptsTable
-        receipts={receipts}
-        loading={loading}
-        onRowClick={(r) => setSelected(r)}
-        onDelete={handleDelete}
-      />
+      {/* ─── Main ────────────────────────────────────────────── */}
+      <div className={styles.main}>
+        <header className={styles.header}>
+          <div className={styles.headerTitle}>{activeNav.label}</div>
+          <div className={styles.headerRight}>
+            <div className={styles.userMenu}>
+              <div className={styles.userAvatar}>{avatarInitial}</div>
+              <span className={styles.userName}>{email || 'Not signed in'}</span>
+            </div>
+          </div>
+        </header>
+
+        <main className={styles.content}>
+          {view === 'expenses' && (
+            <ExpensesView
+              stats={stats}
+              receipts={receipts}
+              loading={loading}
+              error={error}
+              statusFilter={statusFilter}
+              setStatusFilter={setStatusFilter}
+              mineOnly={mineOnly}
+              setMineOnly={setMineOnly}
+              search={search}
+              setSearch={setSearch}
+              uploading={uploading}
+              onUpload={handleUpload}
+              onAdd={() => {
+                setForm(EMPTY_FORM);
+                setShowManual(true);
+              }}
+              onRowClick={(r) => setSelected(r)}
+              onDelete={handleDelete}
+            />
+          )}
+
+          {view === 'dashboard' && <DashboardView stats={stats} />}
+
+          {activeNav.placeholder && (
+            <Placeholder label={activeNav.label} />
+          )}
+        </main>
+      </div>
 
       {showManual && (
         <ManualEntryModal
@@ -267,48 +320,185 @@ export default function CreditCardReceiptsPage() {
         />
       )}
 
-      {toast && <Toast toast={toast} />}
+      {toast && (
+        <div
+          className={`${styles.toast} ${
+            toast.variant === 'success' ? styles.toastSuccess : toast.variant === 'error' ? styles.toastError : ''
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
     </div>
   );
 }
 
 // ============================================================================
-// Sub-components
+// Views
 // ============================================================================
 
-function PageHeader({ onAdd, onUpload, uploading }) {
+function ExpensesView({
+  stats, receipts, loading, error,
+  statusFilter, setStatusFilter, mineOnly, setMineOnly, search, setSearch,
+  uploading, onUpload, onAdd, onRowClick, onDelete,
+}) {
   return (
-    <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
-      <div>
-        <h1 style={{ fontSize: '24px', fontWeight: 600, color: BLUE, marginBottom: '8px' }}>
-          Credit Card Receipts
-        </h1>
-        <p style={{ fontSize: '14px', color: MUTED, marginBottom: '24px' }}>
-          Submit, track, and reconcile credit card receipts against Amex transactions.
-        </p>
+    <>
+      <div className={styles.pageHeader}>
+        <div>
+          <div className={styles.pageTitle}>Business Expenses</div>
+          <div className={styles.pageSubtitle}>
+            Submit, track, and reconcile credit card receipts against Amex transactions.
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <label className={`${styles.btn} ${styles.btnSecondary} ${styles.uploadLabel}`} style={{ cursor: uploading ? 'wait' : 'pointer' }}>
+            <span>⬆</span>
+            {uploading ? 'Uploading…' : 'Upload receipt'}
+            <input
+              type="file"
+              accept="image/*,application/pdf"
+              style={{ display: 'none' }}
+              disabled={uploading}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                e.target.value = '';
+                onUpload(f);
+              }}
+            />
+          </label>
+          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={onAdd}>
+            <span>＋</span> Add receipt
+          </button>
+        </div>
       </div>
-      <div style={{ display: 'flex', gap: 8 }}>
-        <label style={{ ...btnGhost, cursor: uploading ? 'wait' : 'pointer' }}>
-          <span className="fas fa-upload" style={{ marginRight: 6 }} />
-          {uploading ? 'Uploading…' : 'Upload receipt'}
-          <input
-            type="file"
-            accept="image/*,application/pdf"
-            style={{ display: 'none' }}
-            disabled={uploading}
-            onChange={(e) => {
-              const f = e.target.files?.[0];
-              e.target.value = '';
-              onUpload(f);
-            }}
-          />
-        </label>
-        <button style={btnPrimary} onClick={onAdd}>
-          <span className="fas fa-plus" style={{ marginRight: 6 }} />
-          Add receipt
-        </button>
+
+      <SummaryTiles stats={stats} />
+
+      <div className={styles.tableWrapper}>
+        <div className={styles.tableToolbar}>
+          <div className={styles.tableFilters}>
+            {STATUS_TABS.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => setStatusFilter(tab.key)}
+                className={`${styles.btn} ${statusFilter === tab.key ? styles.btnPrimary : styles.btnGhost}`}
+                style={{ padding: '5px 12px', fontSize: 12 }}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className={styles.tableFilters}>
+            <input
+              className={styles.formInput}
+              style={{ width: 220 }}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search vendor, GL, notes…"
+            />
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--color-text-muted)', cursor: 'pointer' }}>
+              <input type="checkbox" checked={mineOnly} onChange={(e) => setMineOnly(e.target.checked)} />
+              Mine only
+            </label>
+          </div>
+        </div>
+
+        {error ? (
+          <div className={styles.emptyState} style={{ color: 'var(--color-danger)' }}>{error}</div>
+        ) : loading ? (
+          <div className={styles.emptyState}>Loading receipts…</div>
+        ) : receipts.length === 0 ? (
+          <div className={styles.emptyState}>
+            <div className={styles.emptyIcon}>🧾</div>
+            <div className={styles.emptyTitle}>No receipts yet</div>
+            <div className={styles.emptyMessage}>
+              Upload a receipt image/PDF or add one manually to get started.
+            </div>
+          </div>
+        ) : (
+          <table className={styles.dataTable}>
+            <thead>
+              <tr>
+                <th>Receipt</th>
+                <th>Date</th>
+                <th>Vendor</th>
+                <th className={styles.right}>Amount</th>
+                <th>GL account</th>
+                <th>Location</th>
+                <th>Card</th>
+                <th>Status</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {receipts.map((r) => (
+                <tr key={r.id} onClick={() => onRowClick(r)}>
+                  <td>
+                    {r.image_path ? <span title="Has file">🧾</span> : <span style={{ opacity: 0.3 }} title="No file">○</span>}
+                  </td>
+                  <td>{fmtDate(r.date)}</td>
+                  <td style={{ fontWeight: 500 }}>
+                    {r.vendor || <span style={{ color: 'var(--color-text-subtle)' }}>Unknown</span>}
+                  </td>
+                  <td className={`${styles.right} ${styles.money}`}>{money(r.amount)}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.gl_account || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.location || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.card_last4 ? `•••• ${r.card_last4}` : '—'}</td>
+                  <td><StatusBadge status={r.match_status} /></td>
+                  <td className={styles.right}>
+                    <button
+                      title="Delete"
+                      className={styles.iconBtn}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(r.id);
+                      }}
+                    >
+                      🗑
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
-    </div>
+    </>
+  );
+}
+
+function DashboardView({ stats }) {
+  return (
+    <>
+      <div className={styles.pageHeader}>
+        <div>
+          <div className={styles.pageTitle}>Dashboard</div>
+          <div className={styles.pageSubtitle}>Receipt reconciliation overview.</div>
+        </div>
+      </div>
+      <SummaryTiles stats={stats} />
+    </>
+  );
+}
+
+function Placeholder({ label }) {
+  return (
+    <>
+      <div className={styles.pageHeader}>
+        <div className={styles.pageTitle}>{label}</div>
+      </div>
+      <div className={styles.tableWrapper}>
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIcon}>🚧</div>
+          <div className={styles.emptyTitle}>{label} isn’t part of the receipts module yet</div>
+          <div className={styles.emptyMessage}>
+            This view exists in the standalone receipt-agent app. Plaid/Amex feed, expense
+            reports, and QBO export are planned for a later phase.
+          </div>
+        </div>
+      </div>
+    </>
   );
 }
 
@@ -321,200 +511,68 @@ function SummaryTiles({ stats }) {
     { label: 'Disputed', value: stats ? stats.disputed : '—' },
   ];
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 12, marginBottom: 20 }}>
+    <div className={styles.summaryTiles}>
       {tiles.map((t) => (
-        <div key={t.label} style={cardStyle}>
-          <div style={{ fontSize: 12, color: MUTED, marginBottom: 6 }}>{t.label}</div>
-          <div style={{ fontSize: 22, fontWeight: 600, color: '#1f2937' }}>{t.value}</div>
-          {t.suffix ? <div style={{ fontSize: 12, color: FAINT, marginTop: 4 }}>{t.suffix}</div> : null}
+        <div key={t.label} className={styles.summaryTile}>
+          <div className={styles.tileLabel}>{t.label}</div>
+          <div className={styles.tileValue}>{t.value}</div>
+          {t.suffix ? <div className={styles.tileSuffix}>{t.suffix}</div> : null}
         </div>
       ))}
     </div>
   );
 }
 
-function Toolbar({ statusFilter, setStatusFilter, mineOnly, setMineOnly, search, setSearch }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', marginBottom: 12 }}>
-      <div style={{ display: 'flex', gap: 6 }}>
-        {STATUS_TABS.map((tab) => {
-          const active = statusFilter === tab.key;
-          return (
-            <button
-              key={tab.key}
-              onClick={() => setStatusFilter(tab.key)}
-              style={active ? pillActive : pillInactive}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
-      </div>
-      <input
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search vendor, GL, notes…"
-        style={{
-          flex: 1,
-          minWidth: 200,
-          padding: '8px 12px',
-          fontSize: 14,
-          border: `1px solid ${BORDER}`,
-          borderRadius: 8,
-        }}
-      />
-      <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 14, color: MUTED, cursor: 'pointer' }}>
-        <input type="checkbox" checked={mineOnly} onChange={(e) => setMineOnly(e.target.checked)} />
-        Mine only
-      </label>
-    </div>
-  );
-}
-
-function ReceiptsTable({ receipts, loading, onRowClick, onDelete }) {
-  if (loading) {
-    return <div style={{ ...cardStyle, textAlign: 'center', color: MUTED }}>Loading receipts…</div>;
-  }
-  if (receipts.length === 0) {
-    return (
-      <div
-        style={{
-          border: `2px dashed ${BORDER_BLUE}`,
-          borderRadius: 12,
-          padding: 48,
-          textAlign: 'center',
-          color: BLUE,
-          fontSize: 14,
-        }}
-      >
-        <span className="fas fa-receipt" style={{ fontSize: 32, marginBottom: 12, display: 'block', opacity: 0.5 }} />
-        <strong>No receipts yet</strong>
-        <p style={{ marginTop: 8, color: FAINT }}>
-          Upload a receipt image/PDF or add one manually to get started.
-        </p>
-      </div>
-    );
-  }
-  const th = { textAlign: 'left', padding: '10px 12px', fontSize: 12, color: MUTED, fontWeight: 600, borderBottom: `1px solid ${BORDER}` };
-  const td = { padding: '10px 12px', fontSize: 14, borderBottom: `1px solid ${BORDER}`, color: '#1f2937' };
-  return (
-    <div style={{ ...cardStyle, padding: 0, overflow: 'hidden' }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-        <thead>
-          <tr>
-            <th style={th}>Receipt</th>
-            <th style={th}>Date</th>
-            <th style={th}>Vendor</th>
-            <th style={{ ...th, textAlign: 'right' }}>Amount</th>
-            <th style={th}>GL account</th>
-            <th style={th}>Location</th>
-            <th style={th}>Card</th>
-            <th style={th}>Status</th>
-            <th style={th} />
-          </tr>
-        </thead>
-        <tbody>
-          {receipts.map((r) => (
-            <tr
-              key={r.id}
-              onClick={() => onRowClick(r)}
-              style={{ cursor: 'pointer' }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = '#f9fbfd')}
-              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
-            >
-              <td style={td}>
-                {r.image_path ? (
-                  <span className="fas fa-file-invoice" style={{ color: BLUE }} title="Has file" />
-                ) : (
-                  <span className="far fa-circle" style={{ color: FAINT }} title="No file" />
-                )}
-              </td>
-              <td style={td}>{fmtDate(r.date)}</td>
-              <td style={{ ...td, fontWeight: 500 }}>{r.vendor || <em style={{ color: FAINT }}>Unknown</em>}</td>
-              <td style={{ ...td, textAlign: 'right' }}>{money(r.amount)}</td>
-              <td style={{ ...td, color: MUTED }}>{r.gl_account || '—'}</td>
-              <td style={{ ...td, color: MUTED }}>{r.location || '—'}</td>
-              <td style={{ ...td, color: MUTED }}>{r.card_last4 ? `•••• ${r.card_last4}` : '—'}</td>
-              <td style={td}>
-                <StatusBadge status={r.match_status} />
-              </td>
-              <td style={{ ...td, textAlign: 'right' }}>
-                <button
-                  title="Delete"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(r.id);
-                  }}
-                  style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: FAINT }}
-                >
-                  <span className="fas fa-trash" />
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
 function StatusBadge({ status }) {
-  const c = STATUS_COLORS[status] || STATUS_COLORS.unmatched;
-  return (
-    <span
-      style={{
-        display: 'inline-block',
-        padding: '3px 10px',
-        borderRadius: 9999,
-        fontSize: 12,
-        fontWeight: 600,
-        backgroundColor: c.bg,
-        color: c.fg,
-        textTransform: 'capitalize',
-      }}
-    >
-      {status || 'unmatched'}
-    </span>
-  );
+  const cls =
+    status === 'matched' ? styles.badgeMatched : status === 'disputed' ? styles.badgeDisputed : styles.badgeUnmatched;
+  return <span className={`${styles.badge} ${cls}`}>{status || 'unmatched'}</span>;
 }
+
+// ============================================================================
+// Modals
+// ============================================================================
 
 function ManualEntryModal({ form, setForm, saving, onSave, onClose }) {
   const field = (label, key, props = {}) => (
-    <label style={{ display: 'block', marginBottom: 12 }}>
-      <span style={{ display: 'block', fontSize: 12, color: MUTED, marginBottom: 4 }}>{label}</span>
+    <div className={styles.formGroup}>
+      <label className={styles.formLabel}>{label}</label>
       <input
+        className={styles.formInput}
         value={form[key]}
         onChange={(e) => setForm({ ...form, [key]: e.target.value })}
-        style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: `1px solid ${BORDER}`, borderRadius: 8 }}
         {...props}
       />
-    </label>
+    </div>
   );
   return (
-    <Overlay onClose={onClose}>
-      <div style={{ ...modalStyle, maxWidth: 460 }} onClick={(e) => e.stopPropagation()}>
-        <h2 style={{ fontSize: 18, fontWeight: 600, color: BLUE, marginBottom: 16 }}>Add receipt</h2>
-        {field('Vendor *', 'vendor')}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          {field('Amount *', 'amount', { type: 'number', step: '0.01', placeholder: '0.00' })}
-          {field('Date', 'date', { type: 'date' })}
+    <Backdrop onClose={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitle}>Add receipt</div>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
         </div>
-        {field('GL account', 'gl_account', { placeholder: 'Auto-categorized if left blank' })}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          {field('Location', 'location')}
-          {field('Card last 4', 'card_last4', { maxLength: 4 })}
+        <div className={styles.modalBody}>
+          {field('Vendor *', 'vendor')}
+          <div className={styles.formRow}>
+            {field('Amount *', 'amount', { type: 'number', step: '0.01', placeholder: '0.00' })}
+            {field('Date', 'date', { type: 'date' })}
+          </div>
+          {field('GL account', 'gl_account', { placeholder: 'Auto-categorized if left blank' })}
+          <div className={styles.formRow}>
+            {field('Location', 'location')}
+            {field('Card last 4', 'card_last4', { maxLength: 4 })}
+          </div>
+          {field('Notes', 'notes')}
         </div>
-        {field('Notes', 'notes')}
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 8 }}>
-          <button style={btnGhost} onClick={onClose} disabled={saving}>
-            Cancel
-          </button>
-          <button style={btnPrimary} onClick={onSave} disabled={saving}>
+        <div className={styles.modalFooter}>
+          <button className={`${styles.btn} ${styles.btnGhost}`} onClick={onClose} disabled={saving}>Cancel</button>
+          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={onSave} disabled={saving}>
             {saving ? 'Saving…' : 'Save receipt'}
           </button>
         </div>
       </div>
-    </Overlay>
+    </Backdrop>
   );
 }
 
@@ -569,220 +627,96 @@ function ReceiptDrawer({ receipt, onClose, onPatch, onDelete, onSaved, flash }) 
   };
 
   const field = (label, key, props = {}) => (
-    <label style={{ display: 'block', marginBottom: 12 }}>
-      <span style={{ display: 'block', fontSize: 12, color: MUTED, marginBottom: 4 }}>{label}</span>
+    <div className={styles.formGroup}>
+      <label className={styles.formLabel}>{label}</label>
       <input
+        className={styles.formInput}
         value={draft[key] ?? ''}
         onChange={(e) => setDraft({ ...draft, [key]: e.target.value })}
-        style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: `1px solid ${BORDER}`, borderRadius: 8 }}
         {...props}
       />
-    </label>
+    </div>
   );
 
   return (
-    <Overlay onClose={onClose}>
-      <div style={drawerStyle} onClick={(e) => e.stopPropagation()}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <h2 style={{ fontSize: 18, fontWeight: 600, color: BLUE }}>Receipt detail</h2>
-          <button onClick={onClose} style={{ border: 'none', background: 'transparent', fontSize: 18, cursor: 'pointer', color: MUTED }}>
-            <span className="fas fa-times" />
-          </button>
+    <Backdrop onClose={onClose}>
+      <div className={styles.drawer} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitle}>{receipt.vendor || 'Receipt detail'}</div>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
         </div>
-
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
-          {/* Left: editable fields */}
-          <div>
-            {field('Vendor', 'vendor')}
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-              {field('Amount', 'amount', { type: 'number', step: '0.01' })}
-              {field('Date', 'date', { type: 'date' })}
-            </div>
-            {field('GL account', 'gl_account')}
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-              {field('Location', 'location')}
-              {field('Card last 4', 'card_last4', { maxLength: 4 })}
-            </div>
-            <label style={{ display: 'block', marginBottom: 12 }}>
-              <span style={{ display: 'block', fontSize: 12, color: MUTED, marginBottom: 4 }}>Status</span>
-              <select
-                value={draft.match_status}
-                onChange={(e) => setDraft({ ...draft, match_status: e.target.value })}
-                style={{ width: '100%', padding: '8px 10px', fontSize: 14, border: `1px solid ${BORDER}`, borderRadius: 8 }}
-              >
-                <option value="unmatched">Unmatched</option>
-                <option value="matched">Matched</option>
-                <option value="disputed">Disputed</option>
-              </select>
-            </label>
-            {field('Notes', 'notes')}
-
-            <div style={{ display: 'flex', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
-              <button style={btnPrimary} onClick={saveFields} disabled={savingField}>
-                {savingField ? 'Saving…' : 'Save'}
-              </button>
-              <button style={btnGhost} onClick={runMatch} disabled={matching}>
-                {matching ? 'Matching…' : 'Find Amex match'}
-              </button>
-              <button
-                style={{ ...btnGhost, color: '#c0392b', borderColor: '#f3c6c6' }}
-                onClick={() => onDelete(receipt.id)}
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-
-          {/* Right: receipt viewer */}
-          <div>
-            <div style={{ fontSize: 12, color: MUTED, marginBottom: 6 }}>Receipt file</div>
-            {!fileUrl ? (
-              <div
-                style={{
-                  border: `2px dashed ${BORDER_BLUE}`,
-                  borderRadius: 8,
-                  padding: 32,
-                  textAlign: 'center',
-                  color: FAINT,
-                  fontSize: 13,
-                }}
-              >
-                No file attached
+        <div className={styles.modalBody}>
+          <div className={styles.popoutGrid}>
+            {/* Left: editable fields */}
+            <div>
+              {field('Vendor', 'vendor')}
+              <div className={styles.formRow}>
+                {field('Amount', 'amount', { type: 'number', step: '0.01' })}
+                {field('Date', 'date', { type: 'date' })}
               </div>
-            ) : isPdf ? (
-              <iframe title="receipt" src={fileUrl} style={{ width: '100%', height: 420, border: `1px solid ${BORDER}`, borderRadius: 8 }} />
-            ) : (
-              <img
-                src={fileUrl}
-                alt="receipt"
-                style={{ width: '100%', borderRadius: 8, border: `1px solid ${BORDER}` }}
-              />
-            )}
+              {field('GL account', 'gl_account')}
+              <div className={styles.formRow}>
+                {field('Location', 'location')}
+                {field('Card last 4', 'card_last4', { maxLength: 4 })}
+              </div>
+              <div className={styles.formGroup}>
+                <label className={styles.formLabel}>Status</label>
+                <select
+                  className={styles.formSelect}
+                  value={draft.match_status}
+                  onChange={(e) => setDraft({ ...draft, match_status: e.target.value })}
+                >
+                  <option value="unmatched">Unmatched</option>
+                  <option value="matched">Matched</option>
+                  <option value="disputed">Disputed</option>
+                </select>
+              </div>
+              {field('Notes', 'notes')}
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={saveFields} disabled={savingField}>
+                  {savingField ? 'Saving…' : 'Save'}
+                </button>
+                <button className={`${styles.btn} ${styles.btnSecondary}`} onClick={runMatch} disabled={matching}>
+                  {matching ? 'Matching…' : 'Find Amex match'}
+                </button>
+                <button className={`${styles.btn} ${styles.btnDanger}`} onClick={() => onDelete(receipt.id)}>
+                  Delete
+                </button>
+              </div>
+            </div>
+
+            {/* Right: receipt viewer */}
+            <div>
+              <div className={styles.amexCard}>
+                <div className={styles.amexLabel}>Match status</div>
+                <StatusBadge status={receipt.match_status} />
+                {receipt.amex_txn_id ? (
+                  <div style={{ marginTop: 8, fontSize: 12, color: 'var(--color-text-muted)' }}>
+                    Amex txn: {receipt.amex_txn_id}
+                  </div>
+                ) : null}
+              </div>
+              {!fileUrl ? (
+                <div className={styles.receiptViewerEmpty}>No file attached</div>
+              ) : isPdf ? (
+                <iframe title="receipt" src={fileUrl} className={styles.receiptViewer} style={{ width: '100%', height: 420 }} />
+              ) : (
+                <div className={styles.receiptViewer}>
+                  <img src={fileUrl} alt="receipt" style={{ width: '100%', display: 'block' }} />
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
-    </Overlay>
+    </Backdrop>
   );
 }
 
-function Overlay({ children, onClose }) {
+function Backdrop({ children, onClose }) {
   return (
-    <div
-      onClick={onClose}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'rgba(15, 23, 42, 0.45)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-        padding: 24,
-      }}
-    >
+    <div className={styles.modalBackdrop} onClick={onClose}>
       {children}
     </div>
   );
 }
-
-function Toast({ toast }) {
-  const colors = {
-    success: { bg: '#e7f6ec', fg: '#1b7f3b' },
-    error: { bg: '#fdecec', fg: '#c0392b' },
-    info: { bg: '#eaf2fa', fg: BLUE },
-  };
-  const c = colors[toast.variant] || colors.info;
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        bottom: 24,
-        left: '50%',
-        transform: 'translateX(-50%)',
-        background: c.bg,
-        color: c.fg,
-        padding: '10px 18px',
-        borderRadius: 9999,
-        fontSize: 14,
-        fontWeight: 500,
-        boxShadow: '0 4px 14px rgba(0,0,0,0.12)',
-        zIndex: 1100,
-      }}
-    >
-      {toast.message}
-    </div>
-  );
-}
-
-// ─── shared inline styles ──────────────────────────────────────────────────
-const cardStyle = {
-  border: `1px solid ${BORDER}`,
-  borderRadius: 8,
-  padding: 16,
-  background: '#fff',
-};
-
-const btnPrimary = {
-  padding: '8px 16px',
-  borderRadius: 9999,
-  fontSize: 14,
-  fontWeight: 500,
-  border: `1px solid ${BLUE}`,
-  background: BLUE,
-  color: '#fff',
-  cursor: 'pointer',
-};
-
-const btnGhost = {
-  padding: '8px 16px',
-  borderRadius: 9999,
-  fontSize: 14,
-  fontWeight: 500,
-  border: `1px solid ${BLUE}`,
-  background: '#fff',
-  color: BLUE,
-  cursor: 'pointer',
-  display: 'inline-flex',
-  alignItems: 'center',
-};
-
-const pillActive = {
-  padding: '6px 14px',
-  borderRadius: 9999,
-  fontSize: 13,
-  fontWeight: 500,
-  border: `1px solid ${BLUE}`,
-  background: BLUE,
-  color: '#fff',
-  cursor: 'pointer',
-};
-
-const pillInactive = {
-  padding: '6px 14px',
-  borderRadius: 9999,
-  fontSize: 13,
-  fontWeight: 500,
-  border: `1px solid ${BLUE}`,
-  background: '#fff',
-  color: BLUE,
-  cursor: 'pointer',
-};
-
-const modalStyle = {
-  background: '#fff',
-  borderRadius: 12,
-  padding: 24,
-  width: '100%',
-  boxShadow: '0 10px 40px rgba(0,0,0,0.2)',
-};
-
-const drawerStyle = {
-  background: '#fff',
-  borderRadius: 12,
-  padding: 24,
-  width: '100%',
-  maxWidth: 900,
-  maxHeight: '90vh',
-  overflowY: 'auto',
-  boxShadow: '0 10px 40px rgba(0,0,0,0.2)',
-};

--- a/src/ui-pages/CreditCardReceiptsPage.module.css
+++ b/src/ui-pages/CreditCardReceiptsPage.module.css
@@ -1,0 +1,748 @@
+/* ============================================================
+   Credit Card Receipts — Sage brand styling (ported from the
+   receipt-agent Flask app's app.css). Scoped via CSS Modules:
+   all design tokens live on .shell so nothing leaks into the
+   rest of pcs-ui.
+   ============================================================ */
+
+.shell {
+  /* Brand colors */
+  --color-pacific-blue: #008FD7;
+  --color-pacific-blue-dark: #0078B5;
+  --color-pacific-blue-light: #5DB8E8;
+  --color-navy: #1D4469;
+  --color-navy-dark: #142F4A;
+  --color-cream: #EFD6B7;
+  --color-pale-blue: #C5E2EA;
+
+  /* Functional colors */
+  --color-bg: #FFFFFF;
+  --color-bg-subtle: #F7F9FB;
+  --color-border: #E5E7EB;
+  --color-text: #111827;
+  --color-text-muted: #6B7280;
+  --color-text-subtle: #9CA3AF;
+
+  /* Status */
+  --color-success: #10B981;
+  --color-success-bg: #ECFDF5;
+  --color-warning: #F59E0B;
+  --color-warning-bg: #FFFBEB;
+  --color-danger: #EF4444;
+  --color-danger-bg: #FEF2F2;
+  --color-info: #3B82F6;
+  --color-info-bg: #EFF6FF;
+
+  --font-sans: 'Gadugi', 'Segoe UI', system-ui, -apple-system, sans-serif;
+
+  --sidebar-width: 260px;
+  --header-height: 60px;
+
+  --shadow-sm: 0 1px 2px rgba(29, 68, 105, 0.05);
+  --shadow-md: 0 4px 6px rgba(29, 68, 105, 0.07), 0 2px 4px rgba(29, 68, 105, 0.04);
+  --shadow-lg: 0 10px 15px rgba(29, 68, 105, 0.1), 0 4px 6px rgba(29, 68, 105, 0.05);
+  --shadow-xl: 0 20px 25px rgba(29, 68, 105, 0.15), 0 10px 10px rgba(29, 68, 105, 0.04);
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --transition: all 0.15s ease;
+
+  display: flex;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  background-color: var(--color-bg-subtle);
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.shell *,
+.shell *::before,
+.shell *::after {
+  box-sizing: border-box;
+}
+
+/* ─── Sidebar ─────────────────────────────────────────────── */
+.sidebar {
+  width: var(--sidebar-width);
+  background-color: var(--color-navy);
+  color: white;
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  z-index: 50;
+}
+
+.sidebarHeader {
+  padding: 18px 22px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-pacific-blue), var(--color-cream));
+  color: var(--color-navy);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.brandName {
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+}
+
+.brandProduct {
+  font-size: 11px;
+  opacity: 0.6;
+  margin-top: 2px;
+  letter-spacing: 0.3px;
+}
+
+.nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 0;
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 22px;
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 500;
+  font-size: 13px;
+  position: relative;
+  transition: var(--transition);
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+
+.navItem:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.navItemActive {
+  color: white;
+  background-color: rgba(0, 143, 215, 0.15);
+}
+
+.navItemActive::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background-color: var(--color-pacific-blue);
+}
+
+.navIcon {
+  width: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.navLabel {
+  flex: 1;
+}
+
+.navBadge {
+  background-color: var(--color-pacific-blue);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.navSubitem {
+  display: flex;
+  align-items: center;
+  padding: 9px 22px 9px 52px;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 12px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+  position: relative;
+  transition: var(--transition);
+}
+
+.navSubitem:hover {
+  color: white;
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.navSubitemActive {
+  color: white;
+  background-color: rgba(0, 143, 215, 0.15);
+}
+
+.sidebarFooter {
+  padding: 14px 22px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+/* ─── Main content ────────────────────────────────────────── */
+.main {
+  flex: 1;
+  margin-left: var(--sidebar-width);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header {
+  height: var(--header-height);
+  background-color: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 28px;
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  box-shadow: var(--shadow-sm);
+}
+
+.headerTitle {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--color-navy);
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.userMenu {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  background-color: var(--color-bg-subtle);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  font-size: 13px;
+}
+
+.userAvatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-pacific-blue), var(--color-navy));
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.userName {
+  font-weight: 500;
+}
+
+.content {
+  padding: 24px 28px;
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.pageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.pageTitle {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-navy);
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+
+/* ─── Buttons ─────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.btnPrimary {
+  background-color: var(--color-pacific-blue);
+  color: white;
+}
+
+.btnPrimary:hover {
+  background-color: var(--color-pacific-blue-dark);
+}
+
+.btnSecondary {
+  background-color: white;
+  color: var(--color-pacific-blue);
+  border-color: var(--color-pacific-blue);
+}
+
+.btnSecondary:hover {
+  background-color: var(--color-pale-blue);
+}
+
+.btnGhost {
+  background-color: transparent;
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+.btnGhost:hover {
+  background-color: var(--color-bg-subtle);
+  color: var(--color-text);
+}
+
+.btnDanger {
+  background-color: white;
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.btnDanger:hover {
+  background-color: var(--color-danger-bg);
+}
+
+/* ─── Summary tiles ───────────────────────────────────────── */
+.summaryTiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.summaryTile {
+  background-color: white;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+  position: relative;
+  box-shadow: var(--shadow-sm);
+}
+
+.summaryTile::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background-color: var(--color-cream);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
+.tileLabel {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
+.tileValue {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--color-navy);
+  line-height: 1.1;
+}
+
+.tileSuffix {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-top: 4px;
+}
+
+/* ─── Table ───────────────────────────────────────────────── */
+.tableWrapper {
+  background-color: white;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.tableToolbar {
+  padding: 12px 16px;
+  background-color: var(--color-bg-subtle);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tableFilters {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dataTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.dataTable thead {
+  background-color: var(--color-bg-subtle);
+}
+
+.dataTable th {
+  padding: 11px 14px;
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.dataTable td {
+  padding: 14px;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+
+.dataTable tbody tr {
+  transition: var(--transition);
+  cursor: pointer;
+}
+
+.dataTable tbody tr:hover {
+  background-color: var(--color-bg-subtle);
+}
+
+.dataTable tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.right {
+  text-align: right;
+}
+
+.money {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.iconBtn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-text-subtle);
+}
+
+.iconBtn:hover {
+  color: var(--color-danger);
+}
+
+/* ─── Status badges ───────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+
+.badgeMatched {
+  background-color: var(--color-success-bg);
+  color: #065F46;
+  border: 1px solid #6EE7B7;
+}
+
+.badgeUnmatched {
+  background-color: var(--color-warning-bg);
+  color: #92400E;
+  border: 1px solid #FCD34D;
+}
+
+.badgeDisputed {
+  background-color: var(--color-danger-bg);
+  color: #991B1B;
+  border: 1px solid #FCA5A5;
+}
+
+/* ─── Forms ───────────────────────────────────────────────── */
+.formGroup {
+  margin-bottom: 16px;
+}
+
+.formLabel {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.formInput,
+.formSelect {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  background-color: white;
+  transition: var(--transition);
+  color: var(--color-text);
+}
+
+.formInput:focus,
+.formSelect:focus {
+  outline: none;
+  border-color: var(--color-pacific-blue);
+  box-shadow: 0 0 0 3px rgba(0, 143, 215, 0.1);
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+/* ─── Empty state ─────────────────────────────────────────── */
+.emptyState {
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.emptyIcon {
+  font-size: 48px;
+  margin-bottom: 14px;
+  opacity: 0.4;
+}
+
+.emptyTitle {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 5px;
+}
+
+.emptyMessage {
+  font-size: 13px;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+/* ─── Modal / drawer ──────────────────────────────────────── */
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(29, 68, 105, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+}
+
+.modal {
+  background-color: white;
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-xl);
+}
+
+.drawer {
+  background-color: white;
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 980px;
+  max-height: 92vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-xl);
+}
+
+.modalHeader {
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modalTitle {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--color-navy);
+}
+
+.modalClose {
+  background: none;
+  border: none;
+  font-size: 22px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  line-height: 1;
+}
+
+.modalClose:hover {
+  background-color: var(--color-bg-subtle);
+  color: var(--color-text);
+}
+
+.modalBody {
+  padding: 22px;
+}
+
+.modalFooter {
+  padding: 14px 22px;
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg-subtle);
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.popoutGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.amexCard {
+  background-color: var(--color-info-bg);
+  border: 1px solid #BFDBFE;
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+  margin-bottom: 16px;
+}
+
+.amexLabel {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-pacific-blue-dark);
+  margin-bottom: 6px;
+}
+
+.receiptViewer {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-bg-subtle);
+}
+
+.receiptViewerEmpty {
+  border: 2px dashed var(--color-pale-blue);
+  border-radius: var(--radius-md);
+  padding: 40px;
+  text-align: center;
+  color: var(--color-text-subtle);
+  font-size: 13px;
+}
+
+/* ─── Toast ───────────────────────────────────────────────── */
+.toast {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  background-color: white;
+  border-radius: var(--radius-md);
+  padding: 14px 18px;
+  box-shadow: var(--shadow-lg);
+  border-left: 4px solid var(--color-pacific-blue);
+  font-size: 13px;
+  min-width: 280px;
+  z-index: 9999;
+}
+
+.toastSuccess {
+  border-left-color: var(--color-success);
+}
+
+.toastError {
+  border-left-color: var(--color-danger);
+}
+
+/* ─── File-input label styled as a button ─────────────────── */
+.uploadLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    transform: translateX(-100%);
+  }
+  .main {
+    margin-left: 0;
+  }
+  .summaryTiles {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/ui-pages/receipts/CardsView.jsx
+++ b/src/ui-pages/receipts/CardsView.jsx
@@ -1,0 +1,172 @@
+/**
+ * Manage Cards view — Amex card roster with assigned / unassigned tabs and
+ * assign-to-user. A card is any card_last4 seen in transactions or receipts.
+ */
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+import { styles, apiUrl, apiFetch, SummaryTiles, EmptyState, PageHeader, Backdrop } from './shared';
+
+export default function CardsView({ flash }) {
+  const [cards, setCards] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [tab, setTab] = useState('unassigned');
+  const [assignFor, setAssignFor] = useState(null); // card row being assigned
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiFetch(apiUrl('/api/receipts/cards'));
+      setCards(Array.isArray(data.cards) ? data.cards : []);
+      setStats(data.stats || null);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const unassign = async (card) => {
+    if (typeof window !== 'undefined' && !window.confirm(`Unassign card •••• ${card.card_last4}?`)) return;
+    try {
+      await apiFetch(apiUrl(`/api/receipts/cards/${card.card_last4}`), { method: 'DELETE' });
+      flash('Card unassigned', 'success');
+      load();
+    } catch (e) {
+      flash(e.message, 'error');
+    }
+  };
+
+  const visible = cards.filter((c) => (tab === 'assigned' ? c.assigned : !c.assigned));
+  const tiles = [
+    { label: 'Total cards', value: stats ? stats.total : '—' },
+    { label: 'Assigned', value: stats ? stats.assigned : '—' },
+    { label: 'Unassigned', value: stats ? stats.unassigned : '—' },
+  ];
+
+  return (
+    <>
+      <PageHeader title="Manage Cards" subtitle="Assign each corporate card to the team member who manages its receipts." />
+      <SummaryTiles tiles={tiles} />
+
+      <div className={styles.tableWrapper}>
+        <div className={styles.tableToolbar}>
+          <div className={styles.tableFilters}>
+            {['unassigned', 'assigned'].map((k) => (
+              <button key={k} onClick={() => setTab(k)}
+                className={`${styles.btn} ${tab === k ? styles.btnPrimary : styles.btnGhost}`} style={{ padding: '5px 12px', fontSize: 12, textTransform: 'capitalize' }}>
+                {k} ({k === 'assigned' ? stats?.assigned ?? 0 : stats?.unassigned ?? 0})
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error ? (
+          <div className={styles.emptyState} style={{ color: 'var(--color-danger)' }}>{error}</div>
+        ) : loading ? (
+          <div className={styles.emptyState}>Loading cards…</div>
+        ) : visible.length === 0 ? (
+          <EmptyState
+            icon="🗂️"
+            title={tab === 'assigned' ? 'No assigned cards' : 'No unassigned cards'}
+            message={tab === 'assigned' ? 'Assign a card from the Unassigned tab.' : 'Cards appear here once they show up in imported transactions or receipts.'}
+          />
+        ) : (
+          <table className={styles.dataTable}>
+            <thead>
+              <tr>
+                <th>Card</th><th>Cardholder</th>{tab === 'assigned' && <th>Assignee</th>}
+                <th className={styles.right}>Transactions</th><th className={styles.right}>Receipts</th><th />
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((c) => (
+                <tr key={c.card_last4}>
+                  <td style={{ fontWeight: 500 }}>•••• {c.card_last4}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{c.cardholder_name || '—'}</td>
+                  {tab === 'assigned' && <td>{c.assignee_email}</td>}
+                  <td className={styles.right}>{c.txn_count}</td>
+                  <td className={styles.right}>{c.receipt_count}</td>
+                  <td className={styles.right}>
+                    {c.assigned ? (
+                      <>
+                        <button className={`${styles.btn} ${styles.btnGhost}`} style={{ padding: '4px 10px', fontSize: 12 }} onClick={() => setAssignFor(c)}>Reassign</button>{' '}
+                        <button className={`${styles.btn} ${styles.btnDanger}`} style={{ padding: '4px 10px', fontSize: 12 }} onClick={() => unassign(c)}>Unassign</button>
+                      </>
+                    ) : (
+                      <button className={`${styles.btn} ${styles.btnPrimary}`} style={{ padding: '4px 10px', fontSize: 12 }} onClick={() => setAssignFor(c)}>Assign</button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {assignFor && (
+        <AssignModal
+          card={assignFor}
+          onClose={() => setAssignFor(null)}
+          onDone={() => { setAssignFor(null); load(); }}
+          flash={flash}
+        />
+      )}
+    </>
+  );
+}
+
+function AssignModal({ card, onClose, onDone, flash }) {
+  const [email, setEmail] = useState(card.assignee_email || '');
+  const [name, setName] = useState(card.cardholder_name || '');
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    if (!email.trim()) return flash('Assignee email is required', 'error');
+    try {
+      setSaving(true);
+      await apiFetch(apiUrl('/api/receipts/cards'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ card_last4: card.card_last4, assignee_email: email.trim(), cardholder_name: name.trim() }),
+      });
+      flash('Card assigned', 'success');
+      onDone();
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Backdrop onClose={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitle}>Assign card •••• {card.card_last4}</div>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
+        </div>
+        <div className={styles.modalBody}>
+          <div className={styles.formGroup}>
+            <label className={styles.formLabel}>Assignee email *</label>
+            <input className={styles.formInput} value={email} onChange={(e) => setEmail(e.target.value)} placeholder="manager@pcsmiles.com" />
+          </div>
+          <div className={styles.formGroup}>
+            <label className={styles.formLabel}>Cardholder name</label>
+            <input className={styles.formInput} value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+        </div>
+        <div className={styles.modalFooter}>
+          <button className={`${styles.btn} ${styles.btnGhost}`} onClick={onClose} disabled={saving}>Cancel</button>
+          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Save'}</button>
+        </div>
+      </div>
+    </Backdrop>
+  );
+}

--- a/src/ui-pages/receipts/DashboardView.jsx
+++ b/src/ui-pages/receipts/DashboardView.jsx
@@ -1,0 +1,62 @@
+/**
+ * Dashboard view — reconciliation overview across receipts, the Amex feed, and reports.
+ */
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+import { styles, money, apiUrl, apiFetch, SummaryTiles, PageHeader } from './shared';
+
+export default function DashboardView({ flash }) {
+  const [rStats, setRStats] = useState(null);
+  const [tStats, setTStats] = useState(null);
+  const [counts, setCounts] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [r, t, rep] = await Promise.all([
+        apiFetch(apiUrl('/api/receipts')),
+        apiFetch(apiUrl('/api/receipts/transactions')),
+        apiFetch(apiUrl('/api/receipts/reports')),
+      ]);
+      setRStats(r.stats);
+      setTStats(t.stats);
+      setCounts(rep.counts);
+    } catch (e) {
+      flash?.(e.message, 'error');
+    }
+  }, [flash]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const receiptTiles = [
+    { label: 'Total receipts', value: rStats ? rStats.total_count : '—' },
+    { label: 'Receipt spend', value: rStats ? money(rStats.total_amount) : '—' },
+    { label: 'Matched', value: rStats ? rStats.matched : '—', suffix: rStats ? `${rStats.match_pct}% reconciled` : '' },
+    { label: 'Unmatched', value: rStats ? rStats.unmatched : '—' },
+    { label: 'Disputed', value: rStats ? rStats.disputed : '—' },
+  ];
+  const feedTiles = [
+    { label: 'Amex transactions', value: tStats ? tStats.total_count : '—' },
+    { label: 'Card spend', value: tStats ? money(tStats.total_amount) : '—' },
+    { label: 'Txns with receipt', value: tStats ? tStats.matched : '—', suffix: tStats ? `${tStats.match_pct}% covered` : '' },
+    { label: 'Missing receipt', value: tStats ? tStats.unmatched : '—' },
+  ];
+  const reportTiles = [
+    { label: 'Reports submitted', value: counts ? counts.submitted : '—' },
+    { label: 'Approved', value: counts ? counts.approved : '—' },
+    { label: 'Closed', value: counts ? counts.closed : '—' },
+  ];
+
+  return (
+    <>
+      <PageHeader title="Dashboard" subtitle="Receipt reconciliation overview." />
+      <div className={styles.pageTitle} style={{ fontSize: 15, marginBottom: 10 }}>Receipts</div>
+      <SummaryTiles tiles={receiptTiles} />
+      <div className={styles.pageTitle} style={{ fontSize: 15, margin: '8px 0 10px' }}>Amex feed</div>
+      <SummaryTiles tiles={feedTiles} />
+      <div className={styles.pageTitle} style={{ fontSize: 15, margin: '8px 0 10px' }}>Expense reports</div>
+      <SummaryTiles tiles={reportTiles} />
+    </>
+  );
+}

--- a/src/ui-pages/receipts/ExpensesView.jsx
+++ b/src/ui-pages/receipts/ExpensesView.jsx
@@ -1,0 +1,379 @@
+/**
+ * Business Expenses view — the receipts table, intake (upload + manual entry),
+ * detail drawer, and "create expense report from selected".
+ */
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  styles, money, fmtDate, apiUrl, apiFetch, StatusBadge, SummaryTiles, Backdrop, EmptyState, PageHeader,
+} from './shared';
+
+const STATUS_TABS = [
+  { key: 'all', label: 'All' },
+  { key: 'unmatched', label: 'Unmatched' },
+  { key: 'matched', label: 'Matched' },
+  { key: 'disputed', label: 'Disputed' },
+];
+
+const EMPTY_FORM = { vendor: '', amount: '', date: '', gl_account: '', location: '', card_last4: '', notes: '' };
+
+export default function ExpensesView({ flash, onChanged }) {
+  const [receipts, setReceipts] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [mineOnly, setMineOnly] = useState(false);
+  const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [showManual, setShowManual] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [selected, setSelected] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiFetch(
+        apiUrl('/api/receipts', {
+          status: statusFilter === 'all' ? '' : statusFilter,
+          mine: mineOnly ? '1' : '',
+          q: search.trim(),
+        })
+      );
+      setReceipts(Array.isArray(data.receipts) ? data.receipts : []);
+      setStats(data.stats || null);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, mineOnly, search]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleManualSave = async () => {
+    if (!form.vendor.trim()) return flash('Vendor is required', 'error');
+    const amount = parseFloat(form.amount);
+    if (!Number.isFinite(amount) || amount < 0) return flash('Enter a valid amount', 'error');
+    try {
+      setSaving(true);
+      await apiFetch(apiUrl('/api/receipts'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...form, amount }),
+      });
+      flash('Receipt added', 'success');
+      setShowManual(false);
+      setForm(EMPTY_FORM);
+      load();
+      onChanged?.();
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpload = async (file) => {
+    if (!file) return;
+    try {
+      setUploading(true);
+      const fd = new FormData();
+      fd.append('file', file);
+      const data = await apiFetch(apiUrl('/api/receipts'), { method: 'POST', body: fd });
+      flash(data.parseError ? 'Uploaded. Fill fields manually (AI parse unavailable).' : 'Uploaded and parsed', data.parseError ? 'info' : 'success');
+      load();
+      onChanged?.();
+      if (data.receipt) setSelected(data.receipt);
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handlePatch = async (id, patch) => {
+    const data = await apiFetch(apiUrl(`/api/receipts/${id}`), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    return data.receipt;
+  };
+
+  const handleDelete = async (id) => {
+    if (typeof window !== 'undefined' && !window.confirm('Delete this receipt?')) return;
+    try {
+      await apiFetch(apiUrl(`/api/receipts/${id}`), { method: 'DELETE' });
+      flash('Receipt deleted', 'success');
+      setSelected(null);
+      load();
+      onChanged?.();
+    } catch (e) {
+      flash(e.message, 'error');
+    }
+  };
+
+  const createReport = async () => {
+    try {
+      const data = await apiFetch(apiUrl('/api/receipts/reports'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ receiptIds: Array.from(selectedIds) }),
+      });
+      flash(`Report #${data.report.display_number} created (${data.report.expense_count} receipts)`, 'success');
+      setSelectedIds(new Set());
+      load();
+      onChanged?.();
+    } catch (e) {
+      flash(e.message, 'error');
+    }
+  };
+
+  const tiles = [
+    { label: 'Total receipts', value: stats ? stats.total_count : '—' },
+    { label: 'Total amount', value: stats ? money(stats.total_amount) : '—' },
+    { label: 'Matched', value: stats ? stats.matched : '—', suffix: stats ? `${stats.match_pct}% of total` : '' },
+    { label: 'Unmatched', value: stats ? stats.unmatched : '—' },
+    { label: 'Disputed', value: stats ? stats.disputed : '—' },
+  ];
+
+  return (
+    <>
+      <PageHeader
+        title="Business Expenses"
+        subtitle="Submit, track, and reconcile credit card receipts against Amex transactions."
+        actions={
+          <>
+            <label className={`${styles.btn} ${styles.btnSecondary} ${styles.uploadLabel}`} style={{ cursor: uploading ? 'wait' : 'pointer' }}>
+              <span>⬆</span>{uploading ? 'Uploading…' : 'Upload receipt'}
+              <input type="file" accept="image/*,application/pdf" style={{ display: 'none' }} disabled={uploading}
+                onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ''; handleUpload(f); }} />
+            </label>
+            <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => { setForm(EMPTY_FORM); setShowManual(true); }}>
+              <span>＋</span> Add receipt
+            </button>
+          </>
+        }
+      />
+
+      <SummaryTiles tiles={tiles} />
+
+      <div className={styles.tableWrapper}>
+        <div className={styles.tableToolbar}>
+          <div className={styles.tableFilters}>
+            {STATUS_TABS.map((tab) => (
+              <button key={tab.key} onClick={() => setStatusFilter(tab.key)}
+                className={`${styles.btn} ${statusFilter === tab.key ? styles.btnPrimary : styles.btnGhost}`} style={{ padding: '5px 12px', fontSize: 12 }}>
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className={styles.tableFilters}>
+            {selectedIds.size > 0 && (
+              <button className={`${styles.btn} ${styles.btnPrimary}`} style={{ padding: '5px 12px', fontSize: 12 }} onClick={createReport}>
+                Create report ({selectedIds.size})
+              </button>
+            )}
+            <input className={styles.formInput} style={{ width: 220 }} value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search vendor, GL, notes…" />
+            <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: 'var(--color-text-muted)', cursor: 'pointer' }}>
+              <input type="checkbox" checked={mineOnly} onChange={(e) => setMineOnly(e.target.checked)} /> Mine only
+            </label>
+          </div>
+        </div>
+
+        {error ? (
+          <div className={styles.emptyState} style={{ color: 'var(--color-danger)' }}>{error}</div>
+        ) : loading ? (
+          <div className={styles.emptyState}>Loading receipts…</div>
+        ) : receipts.length === 0 ? (
+          <EmptyState icon="🧾" title="No receipts yet" message="Upload a receipt image/PDF or add one manually to get started." />
+        ) : (
+          <table className={styles.dataTable}>
+            <thead>
+              <tr>
+                <th style={{ width: 28 }} />
+                <th>Receipt</th><th>Date</th><th>Vendor</th><th className={styles.right}>Amount</th>
+                <th>GL account</th><th>Location</th><th>Card</th><th>Status</th><th>Report</th><th />
+              </tr>
+            </thead>
+            <tbody>
+              {receipts.map((r) => (
+                <tr key={r.id} onClick={() => setSelected(r)}>
+                  <td onClick={(e) => e.stopPropagation()}>
+                    <input type="checkbox" checked={selectedIds.has(r.id)} disabled={!!r.report_id} onChange={() => toggleSelect(r.id)} />
+                  </td>
+                  <td>{r.image_path ? <span title="Has file">🧾</span> : <span style={{ opacity: 0.3 }}>○</span>}</td>
+                  <td>{fmtDate(r.date)}</td>
+                  <td style={{ fontWeight: 500 }}>{r.vendor || <span style={{ color: 'var(--color-text-subtle)' }}>Unknown</span>}</td>
+                  <td className={`${styles.right} ${styles.money}`}>{money(r.amount)}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.gl_account || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.location || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.card_last4 ? `•••• ${r.card_last4}` : '—'}</td>
+                  <td><StatusBadge status={r.match_status} /></td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.report_id ? '✓' : '—'}</td>
+                  <td className={styles.right}>
+                    <button title="Delete" className={styles.iconBtn} onClick={(e) => { e.stopPropagation(); handleDelete(r.id); }}>🗑</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {showManual && (
+        <ManualEntryModal form={form} setForm={setForm} saving={saving} onSave={handleManualSave} onClose={() => setShowManual(false)} />
+      )}
+      {selected && (
+        <ReceiptDrawer
+          receipt={selected}
+          onClose={() => setSelected(null)}
+          onPatch={handlePatch}
+          onDelete={handleDelete}
+          onSaved={(u) => { setSelected(u); load(); onChanged?.(); }}
+          flash={flash}
+        />
+      )}
+    </>
+  );
+}
+
+function ManualEntryModal({ form, setForm, saving, onSave, onClose }) {
+  const field = (label, key, props = {}) => (
+    <div className={styles.formGroup}>
+      <label className={styles.formLabel}>{label}</label>
+      <input className={styles.formInput} value={form[key]} onChange={(e) => setForm({ ...form, [key]: e.target.value })} {...props} />
+    </div>
+  );
+  return (
+    <Backdrop onClose={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitle}>Add receipt</div>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
+        </div>
+        <div className={styles.modalBody}>
+          {field('Vendor *', 'vendor')}
+          <div className={styles.formRow}>
+            {field('Amount *', 'amount', { type: 'number', step: '0.01', placeholder: '0.00' })}
+            {field('Date', 'date', { type: 'date' })}
+          </div>
+          {field('GL account', 'gl_account', { placeholder: 'Auto-categorized if left blank' })}
+          <div className={styles.formRow}>
+            {field('Location', 'location')}
+            {field('Card last 4', 'card_last4', { maxLength: 4 })}
+          </div>
+          {field('Notes', 'notes')}
+        </div>
+        <div className={styles.modalFooter}>
+          <button className={`${styles.btn} ${styles.btnGhost}`} onClick={onClose} disabled={saving}>Cancel</button>
+          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={onSave} disabled={saving}>{saving ? 'Saving…' : 'Save receipt'}</button>
+        </div>
+      </div>
+    </Backdrop>
+  );
+}
+
+function ReceiptDrawer({ receipt, onClose, onPatch, onDelete, onSaved, flash }) {
+  const [draft, setDraft] = useState(receipt);
+  const [savingField, setSavingField] = useState(false);
+  useEffect(() => { setDraft(receipt); }, [receipt]);
+
+  const isPdf = (receipt.image_path || '').toLowerCase().endsWith('.pdf');
+  const fileUrl = receipt.image_path ? apiUrl(`/api/receipts/${receipt.id}/file`) : null;
+
+  const saveFields = async () => {
+    try {
+      setSavingField(true);
+      const updated = await onPatch(receipt.id, {
+        vendor: draft.vendor, amount: parseFloat(draft.amount) || 0, date: draft.date,
+        gl_account: draft.gl_account, location: draft.location, card_last4: draft.card_last4,
+        notes: draft.notes, match_status: draft.match_status,
+      });
+      flash('Saved', 'success');
+      onSaved(updated);
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setSavingField(false);
+    }
+  };
+
+  const field = (label, key, props = {}) => (
+    <div className={styles.formGroup}>
+      <label className={styles.formLabel}>{label}</label>
+      <input className={styles.formInput} value={draft[key] ?? ''} onChange={(e) => setDraft({ ...draft, [key]: e.target.value })} {...props} />
+    </div>
+  );
+
+  return (
+    <Backdrop onClose={onClose}>
+      <div className={styles.drawer} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitle}>{receipt.vendor || 'Receipt detail'}</div>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
+        </div>
+        <div className={styles.modalBody}>
+          <div className={styles.popoutGrid}>
+            <div>
+              {field('Vendor', 'vendor')}
+              <div className={styles.formRow}>
+                {field('Amount', 'amount', { type: 'number', step: '0.01' })}
+                {field('Date', 'date', { type: 'date' })}
+              </div>
+              {field('GL account', 'gl_account')}
+              <div className={styles.formRow}>
+                {field('Location', 'location')}
+                {field('Card last 4', 'card_last4', { maxLength: 4 })}
+              </div>
+              <div className={styles.formGroup}>
+                <label className={styles.formLabel}>Status</label>
+                <select className={styles.formSelect} value={draft.match_status} onChange={(e) => setDraft({ ...draft, match_status: e.target.value })}>
+                  <option value="unmatched">Unmatched</option>
+                  <option value="matched">Matched</option>
+                  <option value="disputed">Disputed</option>
+                </select>
+              </div>
+              {field('Notes', 'notes')}
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={saveFields} disabled={savingField}>{savingField ? 'Saving…' : 'Save'}</button>
+                <button className={`${styles.btn} ${styles.btnDanger}`} onClick={() => onDelete(receipt.id)}>Delete</button>
+              </div>
+            </div>
+            <div>
+              <div className={styles.amexCard}>
+                <div className={styles.amexLabel}>Match status</div>
+                <StatusBadge status={receipt.match_status} />
+                {receipt.amex_txn_id ? <div style={{ marginTop: 8, fontSize: 12, color: 'var(--color-text-muted)' }}>Amex txn: {receipt.amex_txn_id}</div> : null}
+              </div>
+              {!fileUrl ? (
+                <div className={styles.receiptViewerEmpty}>No file attached</div>
+              ) : isPdf ? (
+                <iframe title="receipt" src={fileUrl} className={styles.receiptViewer} style={{ width: '100%', height: 420 }} />
+              ) : (
+                <div className={styles.receiptViewer}>
+                  <img src={fileUrl} alt="receipt" style={{ width: '100%', display: 'block' }} />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Backdrop>
+  );
+}

--- a/src/ui-pages/receipts/MiscViews.jsx
+++ b/src/ui-pages/receipts/MiscViews.jsx
@@ -1,0 +1,138 @@
+/**
+ * Lighter module views: Integrations, Settings, AI Assistant.
+ * These are intentionally honest about what is/ isn't wired up yet.
+ */
+'use client';
+import React, { useState } from 'react';
+import { styles, apiUrl, apiFetch, EmptyState, PageHeader, currentEmail } from './shared';
+
+// ─── Integrations ────────────────────────────────────────────────────────
+export function IntegrationsView() {
+  const integrations = [
+    {
+      name: 'Plaid (Amex feed)', icon: '🏦', status: 'Not connected',
+      detail: 'Live Amex transaction sync. Today the Transactions feed is populated by CSV/XLSX statement import. Plaid wiring depends on platform credentials owned by the AP/platform team.',
+    },
+    {
+      name: 'QuickBooks Online', icon: '📗', status: 'Managed by platform',
+      detail: 'GL accounts come from the shared chart of accounts. Pushing approved expense reports to QBO uses the platform QBO integration (lib/qbo) and is a later phase for receipts.',
+    },
+    {
+      name: 'AI extraction', icon: '✨', status: 'Configured via env',
+      detail: 'Receipt parsing uses PCS_LLM_PROVIDER / PCS_LLM_MODEL. Uploads still work without it — they just need manual field entry.',
+    },
+  ];
+  return (
+    <>
+      <PageHeader title="Integrations" subtitle="External connections for the receipts module." />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16 }}>
+        {integrations.map((i) => (
+          <div key={i.name} className={styles.summaryTile} style={{ padding: 20 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+              <span style={{ fontSize: 22 }}>{i.icon}</span>
+              <span style={{ fontWeight: 700, color: 'var(--color-navy)' }}>{i.name}</span>
+            </div>
+            <span className={`${styles.badge} ${styles.badgeUnmatched}`}>{i.status}</span>
+            <div style={{ fontSize: 13, color: 'var(--color-text-muted)', marginTop: 10, lineHeight: 1.5 }}>{i.detail}</div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+// ─── Settings ────────────────────────────────────────────────────────────
+export function SettingsView() {
+  const email = currentEmail();
+  const rows = [
+    { label: 'Signed in as', value: email || 'Not signed in' },
+    { label: 'AI parsing', value: 'Model resolved from PCS_LLM_PROVIDER / PCS_LLM_MODEL (server-side)' },
+    { label: 'Match tolerances', value: 'Amount ±$1.00 · Date ±2 days · vendor fuzzy (per module rules)' },
+    { label: 'Auto-categorization', value: 'Keyword rules against the shared chart of accounts' },
+  ];
+  return (
+    <>
+      <PageHeader title="Settings" subtitle="Receipts module configuration." />
+      <div className={styles.tableWrapper}>
+        <table className={styles.dataTable}>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.label}>
+                <td style={{ fontWeight: 600, width: 220 }}>{r.label}</td>
+                <td style={{ color: 'var(--color-text-muted)' }}>{r.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div style={{ fontSize: 12, color: 'var(--color-text-subtle)', marginTop: 12 }}>
+        Editable preferences (GL/class aliases, notifications) are a later phase.
+      </div>
+    </>
+  );
+}
+
+// ─── AI Assistant ──────────────────────────────────────────────────────────
+export function AIAssistantView({ flash }) {
+  const [messages, setMessages] = useState([
+    { role: 'assistant', text: 'Hi! Ask me about your receipts — totals, unmatched items, or what needs attention. (Answers are computed from your live receipt data.)' },
+  ]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  // Lightweight, data-grounded answers computed locally from the receipts API —
+  // no model call, so it works without an LLM key. A richer PCS_LLM-backed chat
+  // can replace answer() later.
+  const answer = async (q) => {
+    const lower = q.toLowerCase();
+    const data = await apiFetch(apiUrl('/api/receipts'));
+    const s = data.stats || {};
+    if (lower.includes('unmatched') || lower.includes('match'))
+      return `${s.unmatched} of ${s.total_count} receipts are unmatched (${s.match_pct}% reconciled).`;
+    if (lower.includes('total') || lower.includes('spend') || lower.includes('amount'))
+      return `Total receipt spend is ${(s.total_amount ?? 0).toLocaleString('en-US', { style: 'currency', currency: 'USD' })} across ${s.total_count} receipts.`;
+    if (lower.includes('disputed'))
+      return `${s.disputed} receipt(s) are currently disputed.`;
+    return `I can answer about totals, unmatched receipts, and disputes. You have ${s.total_count} receipts totalling ${(s.total_amount ?? 0).toLocaleString('en-US', { style: 'currency', currency: 'USD' })}.`;
+  };
+
+  const send = async () => {
+    const q = input.trim();
+    if (!q) return;
+    setMessages((m) => [...m, { role: 'user', text: q }]);
+    setInput('');
+    try {
+      setBusy(true);
+      const a = await answer(q);
+      setMessages((m) => [...m, { role: 'assistant', text: a }]);
+    } catch (e) {
+      flash?.(e.message, 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <PageHeader title="AI Assistant" subtitle="Ask questions about your receipts (beta)." />
+      <div className={styles.tableWrapper} style={{ padding: 16 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, minHeight: 240, marginBottom: 12 }}>
+          {messages.map((m, i) => (
+            <div key={i} style={{ alignSelf: m.role === 'user' ? 'flex-end' : 'flex-start', maxWidth: '75%' }}>
+              <div style={{
+                padding: '8px 12px', borderRadius: 12, fontSize: 13,
+                background: m.role === 'user' ? 'var(--color-pacific-blue)' : 'var(--color-bg-subtle)',
+                color: m.role === 'user' ? 'white' : 'var(--color-text)',
+              }}>{m.text}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <input className={styles.formInput} value={input} onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') send(); }} placeholder="e.g. how many unmatched receipts?" />
+          <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={send} disabled={busy}>{busy ? '…' : 'Send'}</button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/ui-pages/receipts/MiscViews.jsx
+++ b/src/ui-pages/receipts/MiscViews.jsx
@@ -10,12 +10,12 @@ import { styles, apiUrl, apiFetch, EmptyState, PageHeader, currentEmail } from '
 export function IntegrationsView() {
   const integrations = [
     {
-      name: 'Plaid (Amex feed)', icon: '🏦', status: 'Not connected',
-      detail: 'Live Amex transaction sync. Today the Transactions feed is populated by CSV/XLSX statement import. Plaid wiring depends on platform credentials owned by the AP/platform team.',
+      name: 'Plaid (Amex feed)', icon: '🏦', status: 'Available when configured',
+      detail: 'The Transactions page can pull charges via "Sync from Plaid" when PLAID_CLIENT_ID / PLAID_SECRET / PLAID_ACCESS_TOKEN (+ PLAID_ENV) are set. Without them, use CSV/XLSX statement import — both write the same feed.',
     },
     {
-      name: 'QuickBooks Online', icon: '📗', status: 'Managed by platform',
-      detail: 'GL accounts come from the shared chart of accounts. Pushing approved expense reports to QBO uses the platform QBO integration (lib/qbo) and is a later phase for receipts.',
+      name: 'QuickBooks Online', icon: '📗', status: 'Export when connected',
+      detail: 'Approved expense reports can be pushed to QBO as a CreditCard Purchase (uses the platform QBO connection at /api/qbo/auth). GL accounts/classes resolve against the shared chart of accounts.',
     },
     {
       name: 'AI extraction', icon: '✨', status: 'Configured via env',

--- a/src/ui-pages/receipts/MiscViews.jsx
+++ b/src/ui-pages/receipts/MiscViews.jsx
@@ -3,30 +3,159 @@
  * These are intentionally honest about what is/ isn't wired up yet.
  */
 'use client';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { styles, apiUrl, apiFetch, EmptyState, PageHeader, currentEmail } from './shared';
 
+const PLAID_SCRIPT = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+
+function loadPlaidScript() {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined') return reject(new Error('no window'));
+    if (window.Plaid) return resolve();
+    let s = document.getElementById('plaid-link-script');
+    if (s) {
+      s.addEventListener('load', () => resolve());
+      s.addEventListener('error', () => reject(new Error('Failed to load Plaid Link')));
+      return;
+    }
+    s = document.createElement('script');
+    s.id = 'plaid-link-script';
+    s.src = PLAID_SCRIPT;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error('Failed to load Plaid Link'));
+    document.body.appendChild(s);
+  });
+}
+
 // ─── Integrations ────────────────────────────────────────────────────────
-export function IntegrationsView() {
-  const integrations = [
-    {
-      name: 'Plaid (Amex feed)', icon: '🏦', status: 'Available when configured',
-      detail: 'The Transactions page can pull charges via "Sync from Plaid" when PLAID_CLIENT_ID / PLAID_SECRET / PLAID_ACCESS_TOKEN (+ PLAID_ENV) are set. Without them, use CSV/XLSX statement import — both write the same feed.',
-    },
+export function IntegrationsView({ flash }) {
+  const [plaid, setPlaid] = useState(null); // { linkConfigured, env, items }
+  const [connecting, setConnecting] = useState(false);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const data = await apiFetch(apiUrl('/api/receipts/integrations/plaid'));
+      setPlaid(data);
+    } catch (e) {
+      flash?.(e.message, 'error');
+    }
+  }, [flash]);
+
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
+
+  const connect = async () => {
+    try {
+      setConnecting(true);
+      const { link_token } = await apiFetch(apiUrl('/api/receipts/integrations/plaid/link-token'), { method: 'POST' });
+      await loadPlaidScript();
+      const handler = window.Plaid.create({
+        token: link_token,
+        onSuccess: async (public_token, metadata) => {
+          try {
+            await apiFetch(apiUrl('/api/receipts/integrations/plaid/exchange'), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ public_token, institution_name: metadata?.institution?.name || '' }),
+            });
+            flash?.('Bank connected', 'success');
+            loadStatus();
+          } catch (e) {
+            flash?.(e.message, 'error');
+          }
+        },
+        onExit: (err) => { if (err) flash?.(err.display_message || err.error_message || 'Plaid Link closed', 'info'); },
+      });
+      handler.open();
+    } catch (e) {
+      flash?.(e.message, 'info'); // e.g. "Plaid is not configured…"
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const disconnect = async (itemId) => {
+    if (typeof window !== 'undefined' && !window.confirm('Disconnect this bank?')) return;
+    try {
+      await apiFetch(apiUrl(`/api/receipts/integrations/plaid?item_id=${encodeURIComponent(itemId)}`), { method: 'DELETE' });
+      flash?.('Disconnected', 'success');
+      loadStatus();
+    } catch (e) {
+      flash?.(e.message, 'error');
+    }
+  };
+
+  const staticCards = [
     {
       name: 'QuickBooks Online', icon: '📗', status: 'Export when connected',
-      detail: 'Approved expense reports can be pushed to QBO as a CreditCard Purchase (uses the platform QBO connection at /api/qbo/auth). GL accounts/classes resolve against the shared chart of accounts.',
+      detail: 'Approved expense reports push to QBO as a CreditCard Purchase (uses the platform QBO connection at /api/qbo/auth). GL accounts/classes resolve against the shared chart of accounts.',
     },
     {
       name: 'AI extraction', icon: '✨', status: 'Configured via env',
       detail: 'Receipt parsing uses PCS_LLM_PROVIDER / PCS_LLM_MODEL. Uploads still work without it — they just need manual field entry.',
     },
   ];
+
   return (
     <>
       <PageHeader title="Integrations" subtitle="External connections for the receipts module." />
+
+      {/* Plaid — interactive connect */}
+      <div className={styles.summaryTile} style={{ padding: 20, marginBottom: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span style={{ fontSize: 22 }}>🏦</span>
+            <span style={{ fontWeight: 700, color: 'var(--color-navy)' }}>Plaid (Amex feed)</span>
+            {plaid && (
+              <span className={`${styles.badge} ${plaid.items?.length ? styles.badgeMatched : styles.badgeUnmatched}`}>
+                {plaid.items?.length ? `${plaid.items.length} connected` : plaid.linkConfigured ? 'Ready to connect' : 'Not configured'}
+              </span>
+            )}
+          </div>
+          {plaid?.linkConfigured ? (
+            <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={connect} disabled={connecting}>
+              {connecting ? 'Opening…' : '+ Connect a bank'}
+            </button>
+          ) : null}
+        </div>
+
+        {plaid && !plaid.linkConfigured && (
+          <div style={{ fontSize: 13, color: 'var(--color-text-muted)', marginTop: 10, lineHeight: 1.5 }}>
+            Set <code>PLAID_CLIENT_ID</code> and <code>PLAID_SECRET</code> (and <code>PLAID_ENV</code>) on the server to
+            enable Plaid Link. Until then, use CSV/XLSX statement import on the Transactions page — both write the same feed.
+          </div>
+        )}
+
+        {plaid?.items?.length > 0 && (
+          <table className={styles.dataTable} style={{ marginTop: 12 }}>
+            <thead>
+              <tr><th>Institution</th><th>Connected by</th><th>Last synced</th><th /></tr>
+            </thead>
+            <tbody>
+              {plaid.items.map((it) => (
+                <tr key={it.item_id}>
+                  <td style={{ fontWeight: 500 }}>{it.institution_name || it.item_id}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{it.connected_by || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{it.last_synced_at ? new Date(it.last_synced_at).toLocaleString() : 'never'}</td>
+                  <td className={styles.right}>
+                    <button className={`${styles.btn} ${styles.btnDanger}`} style={{ padding: '4px 10px', fontSize: 12 }} onClick={() => disconnect(it.item_id)}>Disconnect</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        {plaid?.items?.length > 0 && (
+          <div style={{ fontSize: 12, color: 'var(--color-text-subtle)', marginTop: 8 }}>
+            Pull charges anytime from the Transactions page → “Sync from Plaid”.
+          </div>
+        )}
+      </div>
+
+      {/* Static integration cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16 }}>
-        {integrations.map((i) => (
+        {staticCards.map((i) => (
           <div key={i.name} className={styles.summaryTile} style={{ padding: 20 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
               <span style={{ fontSize: 22 }}>{i.icon}</span>

--- a/src/ui-pages/receipts/ReportsView.jsx
+++ b/src/ui-pages/receipts/ReportsView.jsx
@@ -140,6 +140,20 @@ function ReportDrawer({ id, onClose, onChanged, flash }) {
     }
   };
 
+  const exportQbo = async () => {
+    try {
+      setBusy(true);
+      const data = await apiFetch(apiUrl(`/api/receipts/reports/${id}/export`), { method: 'POST' });
+      setReport(data.report);
+      flash(`Exported to QuickBooks (Purchase ${data.purchaseId})`, 'success');
+      onChanged?.();
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <Backdrop onClose={onClose}>
       <div className={styles.drawer} onClick={(e) => e.stopPropagation()}>
@@ -167,10 +181,19 @@ function ReportDrawer({ id, onClose, onChanged, flash }) {
                   <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => setStatus('approved')} disabled={busy}>Approve</button>
                 )}
                 {report.status === 'approved' && (
-                  <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => setStatus('closed')} disabled={busy}>Close</button>
+                  <>
+                    <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={exportQbo} disabled={busy}>Export to QuickBooks</button>
+                    <button className={`${styles.btn} ${styles.btnGhost}`} onClick={() => setStatus('closed')} disabled={busy}>Close (no export)</button>
+                  </>
                 )}
                 {report.status !== 'submitted' && report.status !== 'closed' && (
                   <button className={`${styles.btn} ${styles.btnGhost}`} onClick={() => setStatus('submitted')} disabled={busy}>Reopen</button>
+                )}
+                {report.qbo_purchase_id && (
+                  <span className={`${styles.badge} ${styles.badgeMatched}`}>QBO Purchase {report.qbo_purchase_id}</span>
+                )}
+                {report.qbo_export_error && !report.qbo_purchase_id && (
+                  <span style={{ fontSize: 12, color: 'var(--color-danger)' }}>Last export error: {report.qbo_export_error}</span>
                 )}
               </div>
 

--- a/src/ui-pages/receipts/ReportsView.jsx
+++ b/src/ui-pages/receipts/ReportsView.jsx
@@ -1,0 +1,199 @@
+/**
+ * Expense Reports view — bundles of receipts moving through
+ * submitted → approved → closed, with a detail drawer.
+ */
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  styles, money, fmtDate, apiUrl, apiFetch, StatusBadge, SummaryTiles, EmptyState, PageHeader, Backdrop,
+} from './shared';
+
+const TABS = [
+  { key: 'submitted', label: 'Submitted' },
+  { key: 'approved', label: 'Approved' },
+  { key: 'closed', label: 'Closed' },
+];
+
+export default function ReportsView({ flash, onChanged }) {
+  const [reports, setReports] = useState([]);
+  const [counts, setCounts] = useState({ submitted: 0, approved: 0, closed: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [tab, setTab] = useState('submitted');
+  const [openId, setOpenId] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiFetch(apiUrl('/api/receipts/reports', { status: tab }));
+      setReports(Array.isArray(data.reports) ? data.reports : []);
+      setCounts(data.counts || { submitted: 0, approved: 0, closed: 0 });
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [tab]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const tiles = [
+    { label: 'Submitted', value: counts.submitted },
+    { label: 'Approved', value: counts.approved },
+    { label: 'Closed', value: counts.closed },
+  ];
+
+  return (
+    <>
+      <PageHeader title="Expense Reports" subtitle="Receipts bundled and submitted together for approval." />
+      <SummaryTiles tiles={tiles} />
+
+      <div className={styles.tableWrapper}>
+        <div className={styles.tableToolbar}>
+          <div className={styles.tableFilters}>
+            {TABS.map((t) => (
+              <button key={t.key} onClick={() => setTab(t.key)}
+                className={`${styles.btn} ${tab === t.key ? styles.btnPrimary : styles.btnGhost}`} style={{ padding: '5px 12px', fontSize: 12 }}>
+                {t.label} ({counts[t.key] ?? 0})
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {error ? (
+          <div className={styles.emptyState} style={{ color: 'var(--color-danger)' }}>{error}</div>
+        ) : loading ? (
+          <div className={styles.emptyState}>Loading reports…</div>
+        ) : reports.length === 0 ? (
+          <EmptyState icon="📑" title="No reports here" message="Create a report by selecting receipts on the Business Expenses page." />
+        ) : (
+          <table className={styles.dataTable}>
+            <thead>
+              <tr>
+                <th>Report</th><th>Submitted by</th><th>Submitted</th>
+                <th className={styles.right}>Receipts</th><th className={styles.right}>Amount</th><th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reports.map((r) => (
+                <tr key={r.id} onClick={() => setOpenId(r.id)}>
+                  <td style={{ fontWeight: 600 }}>Report #{r.display_number}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{r.submitted_by}</td>
+                  <td>{fmtDate(r.submitted_at)}</td>
+                  <td className={styles.right}>{r.expense_count}</td>
+                  <td className={`${styles.right} ${styles.money}`}>{money(r.total_amount)}</td>
+                  <td><StatusBadge status={r.status} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {openId && (
+        <ReportDrawer
+          id={openId}
+          onClose={() => setOpenId(null)}
+          onChanged={() => { load(); onChanged?.(); }}
+          flash={flash}
+        />
+      )}
+    </>
+  );
+}
+
+function ReportDrawer({ id, onClose, onChanged, flash }) {
+  const [report, setReport] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await apiFetch(apiUrl(`/api/receipts/reports/${id}`));
+      setReport(data.report);
+    } catch (e) {
+      flash(e.message, 'error');
+    }
+  }, [id, flash]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const setStatus = async (status) => {
+    try {
+      setBusy(true);
+      const data = await apiFetch(apiUrl(`/api/receipts/reports/${id}`), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      setReport(data.report);
+      flash(`Report ${status}`, 'success');
+      onChanged?.();
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Backdrop onClose={onClose}>
+      <div className={styles.drawer} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <div className={styles.modalTitle}>{report ? `Report #${report.display_number}` : 'Report'}</div>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
+        </div>
+        <div className={styles.modalBody}>
+          {!report ? (
+            <div className={styles.emptyState}>Loading…</div>
+          ) : (
+            <>
+              <div className={styles.amexCard} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div>
+                  <div style={{ fontSize: 13, color: 'var(--color-text-muted)' }}>Submitted by {report.submitted_by} · {fmtDate(report.submitted_at)}</div>
+                  <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--color-navy)', marginTop: 4 }}>
+                    {money(report.total_amount)} · {report.expense_count} receipts
+                  </div>
+                </div>
+                <StatusBadge status={report.status} />
+              </div>
+
+              <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
+                {report.status === 'submitted' && (
+                  <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => setStatus('approved')} disabled={busy}>Approve</button>
+                )}
+                {report.status === 'approved' && (
+                  <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={() => setStatus('closed')} disabled={busy}>Close</button>
+                )}
+                {report.status !== 'submitted' && report.status !== 'closed' && (
+                  <button className={`${styles.btn} ${styles.btnGhost}`} onClick={() => setStatus('submitted')} disabled={busy}>Reopen</button>
+                )}
+              </div>
+
+              <table className={styles.dataTable}>
+                <thead>
+                  <tr><th>Date</th><th>Vendor</th><th className={styles.right}>Amount</th><th>GL account</th><th>Status</th></tr>
+                </thead>
+                <tbody>
+                  {report.receipts.map((r) => (
+                    <tr key={r.id}>
+                      <td>{fmtDate(r.date)}</td>
+                      <td style={{ fontWeight: 500 }}>{r.vendor || '—'}</td>
+                      <td className={`${styles.right} ${styles.money}`}>{money(r.amount)}</td>
+                      <td style={{ color: 'var(--color-text-muted)' }}>{r.gl_account || '—'}</td>
+                      <td><StatusBadge status={r.match_status} /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+        </div>
+      </div>
+    </Backdrop>
+  );
+}

--- a/src/ui-pages/receipts/TasksView.jsx
+++ b/src/ui-pages/receipts/TasksView.jsx
@@ -1,0 +1,99 @@
+/**
+ * Tasks view — a derived to-do list: what needs attention across the module.
+ */
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+import { styles, money, fmtDate, apiUrl, apiFetch, EmptyState, PageHeader } from './shared';
+
+export default function TasksView({ flash, goTo }) {
+  const [receipts, setReceipts] = useState([]);
+  const [txns, setTxns] = useState([]);
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [r, t, rep] = await Promise.all([
+        apiFetch(apiUrl('/api/receipts')),
+        apiFetch(apiUrl('/api/receipts/transactions', { status: 'unmatched' })),
+        apiFetch(apiUrl('/api/receipts/reports', { status: 'submitted' })),
+      ]);
+      setReceipts(r.receipts || []);
+      setTxns(t.transactions || []);
+      setReports(rep.reports || []);
+    } catch (e) {
+      flash?.(e.message, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [flash]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const unmatchedReceipts = receipts.filter((r) => r.match_status === 'unmatched');
+  const missingGl = receipts.filter((r) => !r.gl_account || r.gl_account === '59000 Uncategorized Expense');
+
+  const categories = [
+    {
+      icon: '🔗', title: 'Receipts awaiting an Amex match', urgent: true,
+      items: unmatchedReceipts.slice(0, 8).map((r) => ({ key: r.id, title: r.vendor || 'Unknown vendor', meta: `${fmtDate(r.date)} · ${money(r.amount)}` })),
+      count: unmatchedReceipts.length, action: () => goTo?.('expenses'),
+    },
+    {
+      icon: '🏷️', title: 'Receipts needing a GL account', urgent: false,
+      items: missingGl.slice(0, 8).map((r) => ({ key: r.id, title: r.vendor || 'Unknown vendor', meta: money(r.amount) })),
+      count: missingGl.length, action: () => goTo?.('expenses'),
+    },
+    {
+      icon: '💳', title: 'Card charges missing a receipt', urgent: false,
+      items: txns.slice(0, 8).map((t) => ({ key: t.id, title: t.merchant_name || 'Unknown merchant', meta: `${fmtDate(t.transaction_date)} · ${money(t.amount)}` })),
+      count: txns.length, action: () => goTo?.('transactions'),
+    },
+    {
+      icon: '📑', title: 'Reports awaiting approval', urgent: true,
+      items: reports.slice(0, 8).map((r) => ({ key: r.id, title: `Report #${r.display_number}`, meta: `${r.submitted_by} · ${money(r.total_amount)}` })),
+      count: reports.length, action: () => goTo?.('reports'),
+    },
+  ].filter((c) => c.count > 0);
+
+  return (
+    <>
+      <PageHeader title="Tasks" subtitle="What needs your attention across the receipts module." />
+      {loading ? (
+        <div className={styles.tableWrapper}><div className={styles.emptyState}>Loading tasks…</div></div>
+      ) : categories.length === 0 ? (
+        <div className={styles.tableWrapper}>
+          <EmptyState icon="✅" title="All caught up" message="No unmatched receipts, missing GL codes, uncovered charges, or pending reports." />
+        </div>
+      ) : (
+        categories.map((c) => (
+          <div key={c.title} className={styles.tableWrapper} style={{ marginBottom: 16 }}>
+            <div className={styles.tableToolbar}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontWeight: 600, color: 'var(--color-navy)' }}>
+                <span>{c.icon}</span>{c.title}
+                <span className={`${styles.badge} ${c.urgent ? styles.badgeDisputed : styles.badgeUnmatched}`}>{c.count}</span>
+              </div>
+              <button className={`${styles.btn} ${styles.btnGhost}`} style={{ padding: '4px 10px', fontSize: 12 }} onClick={c.action}>Open</button>
+            </div>
+            <table className={styles.dataTable}>
+              <tbody>
+                {c.items.map((it) => (
+                  <tr key={it.key} onClick={c.action}>
+                    <td style={{ fontWeight: 500 }}>{it.title}</td>
+                    <td className={styles.right} style={{ color: 'var(--color-text-muted)' }}>{it.meta}</td>
+                  </tr>
+                ))}
+                {c.count > c.items.length && (
+                  <tr><td colSpan={2} style={{ color: 'var(--color-text-subtle)', fontSize: 12 }}>+ {c.count - c.items.length} more…</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        ))
+      )}
+    </>
+  );
+}

--- a/src/ui-pages/receipts/TransactionsView.jsx
+++ b/src/ui-pages/receipts/TransactionsView.jsx
@@ -22,6 +22,7 @@ export default function TransactionsView({ flash, onChanged }) {
   const [search, setSearch] = useState('');
   const [importing, setImporting] = useState(false);
   const [matching, setMatching] = useState(false);
+  const [syncing, setSyncing] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -62,6 +63,19 @@ export default function TransactionsView({ flash, onChanged }) {
     }
   };
 
+  const syncPlaid = async () => {
+    try {
+      setSyncing(true);
+      const data = await apiFetch(apiUrl('/api/receipts/transactions/sync'), { method: 'POST' });
+      flash(`Plaid sync: ${data.inserted} new (${data.skipped} duplicates)`, 'success');
+      load();
+    } catch (e) {
+      flash(e.message, 'info'); // e.g. "Plaid is not configured…"
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   const runMatch = async () => {
     try {
       setMatching(true);
@@ -95,6 +109,9 @@ export default function TransactionsView({ flash, onChanged }) {
               <input type="file" accept=".csv,.xlsx,.xls" style={{ display: 'none' }} disabled={importing}
                 onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ''; handleImport(f); }} />
             </label>
+            <button className={`${styles.btn} ${styles.btnGhost}`} onClick={syncPlaid} disabled={syncing}>
+              {syncing ? 'Syncing…' : '🏦 Sync from Plaid'}
+            </button>
             <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={runMatch} disabled={matching}>
               {matching ? 'Matching…' : '⟳ Reconcile receipts'}
             </button>

--- a/src/ui-pages/receipts/TransactionsView.jsx
+++ b/src/ui-pages/receipts/TransactionsView.jsx
@@ -1,0 +1,152 @@
+/**
+ * Transactions view — Amex feed (statement import) + reconcile against receipts.
+ */
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  styles, money, fmtDate, apiUrl, apiFetch, StatusBadge, SummaryTiles, EmptyState, PageHeader,
+} from './shared';
+
+const STATUS_TABS = [
+  { key: 'all', label: 'All' },
+  { key: 'unmatched', label: 'No receipt' },
+  { key: 'matched', label: 'Matched' },
+];
+
+export default function TransactionsView({ flash, onChanged }) {
+  const [txns, setTxns] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [search, setSearch] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [matching, setMatching] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiFetch(
+        apiUrl('/api/receipts/transactions', {
+          status: statusFilter === 'all' ? '' : statusFilter,
+          q: search.trim(),
+        })
+      );
+      setTxns(Array.isArray(data.transactions) ? data.transactions : []);
+      setStats(data.stats || null);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, search]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleImport = async (file) => {
+    if (!file) return;
+    try {
+      setImporting(true);
+      const fd = new FormData();
+      fd.append('file', file);
+      const data = await apiFetch(apiUrl('/api/receipts/transactions'), { method: 'POST', body: fd });
+      flash(`Imported ${data.inserted} transactions (${data.skipped} duplicates skipped)`, 'success');
+      load();
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const runMatch = async () => {
+    try {
+      setMatching(true);
+      const data = await apiFetch(apiUrl('/api/receipts/transactions/match'), { method: 'POST' });
+      flash(`Reconciled: ${data.matched} of ${data.scanned} unmatched receipts matched`, 'success');
+      load();
+      onChanged?.();
+    } catch (e) {
+      flash(e.message, 'error');
+    } finally {
+      setMatching(false);
+    }
+  };
+
+  const tiles = [
+    { label: 'Total transactions', value: stats ? stats.total_count : '—' },
+    { label: 'Total amount', value: stats ? money(stats.total_amount) : '—' },
+    { label: 'Matched', value: stats ? stats.matched : '—', suffix: stats ? `${stats.match_pct}% of total` : '' },
+    { label: 'No receipt', value: stats ? stats.unmatched : '—' },
+  ];
+
+  return (
+    <>
+      <PageHeader
+        title="Transactions"
+        subtitle="Amex charge feed (read-only). Import a statement, then reconcile against receipts."
+        actions={
+          <>
+            <label className={`${styles.btn} ${styles.btnSecondary} ${styles.uploadLabel}`} style={{ cursor: importing ? 'wait' : 'pointer' }}>
+              <span>⬆</span>{importing ? 'Importing…' : 'Import statement (CSV/XLSX)'}
+              <input type="file" accept=".csv,.xlsx,.xls" style={{ display: 'none' }} disabled={importing}
+                onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ''; handleImport(f); }} />
+            </label>
+            <button className={`${styles.btn} ${styles.btnPrimary}`} onClick={runMatch} disabled={matching}>
+              {matching ? 'Matching…' : '⟳ Reconcile receipts'}
+            </button>
+          </>
+        }
+      />
+
+      <SummaryTiles tiles={tiles} />
+
+      <div className={styles.tableWrapper}>
+        <div className={styles.tableToolbar}>
+          <div className={styles.tableFilters}>
+            {STATUS_TABS.map((tab) => (
+              <button key={tab.key} onClick={() => setStatusFilter(tab.key)}
+                className={`${styles.btn} ${statusFilter === tab.key ? styles.btnPrimary : styles.btnGhost}`} style={{ padding: '5px 12px', fontSize: 12 }}>
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <input className={styles.formInput} style={{ width: 220 }} value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search merchant…" />
+        </div>
+
+        {error ? (
+          <div className={styles.emptyState} style={{ color: 'var(--color-danger)' }}>{error}</div>
+        ) : loading ? (
+          <div className={styles.emptyState}>Loading transactions…</div>
+        ) : txns.length === 0 ? (
+          <EmptyState icon="💳" title="No transactions yet" message="Import an Amex statement (CSV or XLSX) to populate the feed, then reconcile against receipts." />
+        ) : (
+          <table className={styles.dataTable}>
+            <thead>
+              <tr>
+                <th>Date</th><th>Merchant</th><th>Category</th><th>Card</th>
+                <th>Cardholder</th><th className={styles.right}>Amount</th><th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {txns.map((t) => (
+                <tr key={t.id}>
+                  <td>{fmtDate(t.transaction_date)}</td>
+                  <td style={{ fontWeight: 500 }}>{t.merchant_name || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{t.category || '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{t.card_last4 ? `•••• ${t.card_last4}` : '—'}</td>
+                  <td style={{ color: 'var(--color-text-muted)' }}>{t.cardholder_name || '—'}</td>
+                  <td className={`${styles.right} ${styles.money}`}>{money(t.amount)}</td>
+                  <td><StatusBadge status={t.match_status} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/ui-pages/receipts/shared.js
+++ b/src/ui-pages/receipts/shared.js
@@ -1,0 +1,101 @@
+/**
+ * Shared helpers + small UI atoms for the Credit Card Receipts module views.
+ */
+import React from 'react';
+import styles from '../CreditCardReceiptsPage.module.css';
+
+export { styles };
+
+export function money(n) {
+  const v = Number(n) || 0;
+  return v.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+}
+
+export function fmtDate(d) {
+  if (!d) return '—';
+  const parsed = new Date(d);
+  if (Number.isNaN(parsed.getTime())) return d;
+  return parsed.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', year: '2-digit' });
+}
+
+// Forward the current query string (e.g. ?email=...) so API auth works without cookies.
+export function apiUrl(pathname, extra = {}) {
+  const params =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams();
+  Object.entries(extra).forEach(([k, v]) => {
+    if (v === undefined || v === null || v === '') params.delete(k);
+    else params.set(k, String(v));
+  });
+  const qs = params.toString();
+  return `${pathname}${qs ? `?${qs}` : ''}`;
+}
+
+export function currentEmail() {
+  if (typeof window === 'undefined') return '';
+  return new URLSearchParams(window.location.search).get('email') || '';
+}
+
+export async function apiFetch(pathname, opts = {}) {
+  const res = await fetch(apiUrl(pathname), { credentials: 'include', cache: 'no-store', ...opts });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || `Request failed (HTTP ${res.status})`);
+  return data;
+}
+
+export function StatusBadge({ status }) {
+  const cls =
+    status === 'matched'
+      ? styles.badgeMatched
+      : status === 'disputed' || status === 'blocked' || status === 'failed'
+      ? styles.badgeDisputed
+      : status === 'approved' || status === 'closed'
+      ? styles.badgeMatched
+      : styles.badgeUnmatched;
+  return <span className={`${styles.badge} ${cls}`}>{status || 'unmatched'}</span>;
+}
+
+export function SummaryTiles({ tiles }) {
+  return (
+    <div className={styles.summaryTiles}>
+      {tiles.map((t) => (
+        <div key={t.label} className={styles.summaryTile}>
+          <div className={styles.tileLabel}>{t.label}</div>
+          <div className={styles.tileValue}>{t.value}</div>
+          {t.suffix ? <div className={styles.tileSuffix}>{t.suffix}</div> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function Backdrop({ children, onClose }) {
+  return (
+    <div className={styles.modalBackdrop} onClick={onClose}>
+      {children}
+    </div>
+  );
+}
+
+export function EmptyState({ icon, title, message }) {
+  return (
+    <div className={styles.emptyState}>
+      <div className={styles.emptyIcon}>{icon}</div>
+      <div className={styles.emptyTitle}>{title}</div>
+      <div className={styles.emptyMessage}>{message}</div>
+    </div>
+  );
+}
+
+export function PageHeader({ title, subtitle, actions }) {
+  return (
+    <div className={styles.pageHeader}>
+      <div>
+        <div className={styles.pageTitle}>{title}</div>
+        {subtitle ? <div className={styles.pageSubtitle}>{subtitle}</div> : null}
+      </div>
+      {actions ? <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>{actions}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Credit Card Receipts — Sage design + full module build

Brings the receipts module to parity with the standalone receipt-agent app: the Sage look **and** the core pages, plus Plaid sync and QBO export (both gated). Commits:

1. **Restyle to the Sage design** — navy sidebar + topbar, scoped via CSS Modules. `AppLayout.jsx` renders the receipts route full-bleed (top nav suppressed on that route only).
2. **Add the core pages** — Transactions, Manage Cards, Expense Reports, Dashboard, Tasks (+ Integrations/Settings/AI Assistant).
3. **Plaid sync + QBO export** — env/connection-gated integrations.

### Data + API (receipts namespace)
- **Schema** (`lib/db/client.ts`): `amex_transactions`, `card_assignments`, `expense_reports` (+ `qbo_*` cols) + `receipts.report_id`. No other tables touched.
- **Stores/service** (`lib/receipts/`): transactions, cards, reports; `runAutoMatch()`; **`plaid-sync.ts`** (Plaid REST, no SDK dep); **`qbo-export.ts`** (push approved report as a QBO CreditCard Purchase — reuses `lib/qbo` token/lookups **without editing it**).
- **Routes** (`app/api/receipts/**`): transactions (list/stats, CSV/XLSX import, `[id]`, `/match`, `/sync`), cards (roster/assign/unassign), reports (list/counts, create-from-receipts, status, `[id]/export`).

### UI (`src/ui-pages/receipts/*`)
Business Expenses, Transactions (import + **Sync from Plaid** + reconcile), Manage Cards, Expense Reports (submit→approve→**Export to QuickBooks**→closed), Dashboard, Tasks. Shell routes to all views.

### Honest scope / gating (verified to degrade gracefully)
- **Plaid:** `Sync from Plaid` works when `PLAID_CLIENT_ID/PLAID_SECRET/PLAID_ACCESS_TOKEN` are set; otherwise statement import (CSV/XLSX) feeds the same table. Plaid mapping is **untested against a live item** (no creds in dev).
- **QBO:** export works when QBO is connected (`/api/qbo/auth`); resolves GL/classes against the chart of accounts; returns a clear error when not connected or an account can't be mapped. **No changes to `lib/qbo`** — the Purchase POST is done in the receipts module with the platform's stored token, since `QBOClient` only exposes Bill creation.
- **AI Assistant** answers from live receipt stats locally (no key needed).
- **Shared-file edit:** `AppLayout.jsx` (Braxton's) — minimal, route-scoped. @Braxton worth a glance. If you'd prefer `QBOClient` to own a `createPurchase()`, the export can delegate to it.

### Verified
`tsc` 0 errors, ESLint clean. Dev: import → reconcile (1/1), card assign, report create → approve; Plaid/QBO endpoints return clear "not configured / not connected" messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
